### PR TITLE
feat: calculate MW-miles for transmission-expanded change tables

### DIFF
--- a/postreise/analyze/mwmiles.py
+++ b/postreise/analyze/mwmiles.py
@@ -62,6 +62,9 @@ def _calculate_mw_miles(original_grid, ct):
         'mw_miles', 'transformer_mw', 'num_lines', 'num_transformers')
     upgrades = {u: 0 for u in upgrade_categories}
 
+    if 'branch' not in ct or 'branch_id' not in ct['branch']:
+        return upgrades
+
     base_branch = original_grid.branch
     upgraded_branches = ct['branch']['branch_id']
     for b, v in upgraded_branches.items():

--- a/postreise/analyze/test/__init__.py
+++ b/postreise/analyze/test/__init__.py
@@ -1,1 +1,0 @@
-__all__ = ['test_carbon', 'test_mwmiles']

--- a/postreise/analyze/tests/test_mwmiles.py
+++ b/postreise/analyze/tests/test_mwmiles.py
@@ -1,6 +1,6 @@
 import unittest
 
-from tests.mocks import MockGrid
+from postreise.tests.mock_grid import MockGrid
 from postreise.analyze.mwmiles import _calculate_mw_miles
 
 # branch 11 from Seattle to San Francisco (~679 miles)


### PR DESCRIPTION
This branch adds a new script `analyze/mwmiles.py` to calculate the aggregate MW-miles of upgrades from a given Scenario object, with a corresponding `test_mwmiles.py` script. This testing functionality uses several testing tools added in the PR for carbon (#39): the `tests/` folder in root, the `context.py` file to ensure that the tests always import the right version of PostREISE, and the mock objects in `mocks.py`.