### PR TITLE
feat: add info attribute to MockScenario

### DIFF
--- a/postreise/tests/mock_analyze.py
+++ b/postreise/tests/mock_analyze.py
@@ -8,7 +8,15 @@ class MockAnalyze:
         """Constructor.
 
         :param dict grid_attrs: fields to be added to grid.
+        :param pandas.DataFrame congl: dummy congl
+        :param pandas.DataFrame congu: dummy congu
+        :param dict ct: dummy ct
+        :param pandas.DataFrame demand: dummy demand
+        :param pandas.DataFrame lmp: dummy lmp
         :param pandas.DataFrame pg: dummy pg
+        :param pandas.DataFrame solar: dummy solar
+        :param pandas.DataFrame wind: dummy wind
+        :param pandas.DataFrame hydro: dummy hydro
         """
         self.grid = MockGrid(grid_attrs)
         self.congl = congl

--- a/postreise/tests/mock_scenario.py
+++ b/postreise/tests/mock_scenario.py
@@ -10,6 +10,7 @@ class MockScenario:
         :param pandas.DataFrame pg: dummy pg
         """
         self.state = MockAnalyze(grid_attrs, **kwargs)
+        self.info = {id: '111'}
 
     @property
     def __class__(self):


### PR DESCRIPTION
## Purpose
ScenarioInfo object needs to populate the 'info' attribute from Scenario object, which does not exist in MockScenario object and it fails the corresponding tests.

## What is the code doing
Add a dummy 'info' attribute to MockScenario.
Add some missing docs in MockAnalyze.

## Where to look
It is a one line change.

## Time estimate
Very quick.
