### PR TITLE
fix: ensure that MockAnalyze returns a dict for ct

### DIFF
--- a/postreise/tests/mock_analyze.py
+++ b/postreise/tests/mock_analyze.py
@@ -21,7 +21,7 @@ class MockAnalyze:
         self.grid = MockGrid(grid_attrs)
         self.congl = congl
         self.congu = congu
-        self.ct = ct
+        self.ct = ct if ct is not None else {}
         self.demand = demand
         self.lmp = lmp
         self.pg = pg


### PR DESCRIPTION
### Purpose

Make sure that MockAnalyze returns a dictionary when we ask for the change table, even if we don't actually provide one to the object on init. This is needed for the tests for the feature that addresses https://github.com/intvenlab/PowerSimData/issues/116

### What is the code doing?

If given `None` for the `ct` param, return `{}` on calling `get_ct()`.

### Time Estimate

It is one line.