### PR TITLE
refactor: avoid append to speed up extraction

### DIFF
--- a/postreise/extract/extract_data.py
+++ b/postreise/extract/extract_data.py
@@ -99,11 +99,13 @@ def extract_data(scenario_info):
         except AttributeError:
             pass
         for v in extraction_vars:
-            if i > 0:
-                outputs[v] = outputs[v].append(pd.DataFrame(temps[v]))
-            else:
-                outputs[v] = pd.DataFrame(temps[v])
+            if i == 0:
+                interval_length, n_columns = temps[v].shape
+                total_length = end_index * interval_length
+                outputs[v] = pd.DataFrame(np.zeros((total_length, n_columns)))
                 outputs[v].name = scenario_info['id'] + '_' + v.upper()
+            start_hour, end_hour = (i*interval_length), ((i+1)*interval_length)
+            outputs[v].iloc[start_hour:end_hour, :] = temps[v]
     
     print(extraction_vars)
 


### PR DESCRIPTION
### Purpose

Speed up the extraction of simulation results, which have grown to ~1hr now that we are running 24-hour intervals. For 144-hour intervals, extracting results had been very quick, 15 minutes at the most.

### What is the code doing?

The code pre-allocates a DataFrame of the correct size, then adds results from each interval in the appropriate location. This will be more efficient than continually appending (old way), which must change the size of a DataFrame or create a new one of the correct size in every loop.

### Some testing results

I have not tested this on files on the server. However, I have a modified version of `postreise/extract/extract_data.py` which I've been using for extracting results from Julia-created matfiles, and I tested both approaches locally:

old: `100%|████████████████████████████████████████| 366/366 [05:59<00:00,  2.05s/it]`
new: `100%|████████████████████████████████████████| 366/366 [00:17<00:00, 21.01it/s]`

It appears to be a ~20x speedup, so for Eastern scenarios which are ~20 hours to run and ~1 hour to extract, this offers a ~5% improvement in overall throughput.

### Time estimate

30 minutes. I'm not sure if we can test this locally, so we will want to scrutinize the code carefully before deploying/testing on the server.