### PR TITLE
refactor: save congu and congl as sparse DataFrames

### DIFF
--- a/postreise/extract/extract_data.py
+++ b/postreise/extract/extract_data.py
@@ -54,6 +54,7 @@ def extract_data(scenario_info):
     optimize_time = []
 
     extraction_vars = ['pf', 'pg', 'lmp', 'congu', 'congl']
+    sparse_extraction_vars = {'congu', 'congl'}
     temps = {}
     outputs = {}
 
@@ -160,6 +161,10 @@ def extract_data(scenario_info):
             outputs[k].columns = [v]
         else:
             outputs[k].columns = v.tolist()
+
+    # Convert outputs with many zero or near-zero values to sparse dtype
+    for v in sparse_extraction_vars:
+        outputs[v] = outputs[v].round(6).astype(pd.SparseDtype("float", 0))
 
     return outputs
 


### PR DESCRIPTION
### Purpose

Save smaller files for CONGU and CONGL, to save disk space and reduce memory load during analysis.

### What is the code doing

Line 57 defines a subset of the extraction vars (CONGU and CONGL) as 'sparse'.
Lines 165-167 round the values in the sparse extraction vars to six decimal places, then change the dtype of the DataFrame to a Sparse dtype of either floats or `0` values. For more documentation on the Sparse dtype see the documentation at: https://pandas.pydata.org/pandas-docs/version/0.25/user_guide/sparse.html

### Demonstration

On the server, I tried this for the CONGU and CONGL dataframes for scenario 410 (Eastern). `410_CONGU_backup.pkl` and `410_CONGL_backup.pkl` are copies of the original pickle files, while `410_CONGU.pkl` and `410_CONGL.pkl` now contain the sparse dataframes. If we repeat this process on the backup dataframes, we can see a drastic reduction in memory requirements.

```
dolsen@LABPVRE01:/home/EGM/v2/data/output$ python3
Python 3.5.2 (default, Nov 12 2018, 13:43:14)
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pickle
>>> import pandas as pd
>>> with open('410_CONGU_backup.pkl', 'rb') as f:
...     congu = pickle.load(f)
...
>>> congu.memory_usage().sum()
6198693120
>>> sparse_congu = congu.astype(pd.SparseDtype('float', 0))
>>> sparse_congu.memory_usage().sum()
1531710036
>>> sparse_congu = congu.round(6).astype(pd.SparseDtype('float', 0))
>>> sparse_congu.memory_usage().sum()
4341840
>>> congu.memory_usage().sum() / sparse_congu.memory_usage().sum()
1427.6650268089104
```
We get >1000x reduction in memory use.
```
dolsen@LABPVRE01:/home/EGM/v2/data/output$ ls -ltrh
[...]
-rw-rw-r-- 1 dolsen   regroup 5.8G Apr  4 17:43 410_CONGU_backup.pkl
-rw-rw-r-- 1 dolsen   regroup 5.8G Apr  4 17:43 410_CONGL_backup.pkl
-rw-rw-r-- 1 dolsen   regroup  31M Apr  4 17:53 410_CONGU.pkl
-rw-rw-r-- 1 dolsen   regroup  32M Apr  4 17:58 410_CONGL.pkl
```
And a >180x reduction in disk space use.

### Time estimate

Reviewing the code itself should be extremely quick. Theoretically a sparse dtype DataFrame should behave "nearly identical to their dense counterparts" (from the pandas docs). All tests pass in PostREISE, and I've tested these dataframes with the `design_transmission` module of PowerSimData, which seems to be the main (only?) place where they're used now. Maybe half an hour to brainstorm potential pain-points?