### PR TITLE
fix: project negative curtailments to zero

### DIFF
--- a/postreise/plot/analyze_pg.py
+++ b/postreise/plot/analyze_pg.py
@@ -489,7 +489,7 @@ class AnalyzePG:
                     net_demand['net_demand'] = net_demand['net_demand'] - pg_t
                     curtailment_t = self._get_profile(zone, t).sum(
                         axis=1).tolist() - pg_t
-                    pg_stack[key] = curtailment_t
+                    pg_stack[key] = np.clip(curtailment_t, 0, None)
 
             if self.normalize:
                 pg_stack = pg_stack.divide(capacity * self.timestep,


### PR DESCRIPTION
### Purpose

Negative curtailments caused by rounding issues will break the stack plot.

### What is the code doing

Project negatives in `curtailment_t` to zero.

### Validation

I've checked the stacked plot for Scenario 462 and it generated the plots properly. 

### Time to review

5-10 mins