### PR TITLE
fix: typo in module name

### DIFF
--- a/postreise/analyze/__init__.py
+++ b/postreise/analyze/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["generations", "helpers", "transmission"]
+__all__ = ["generation", "helpers", "transmission"]


### PR DESCRIPTION
**Purpose**: change `generations` -> `generation`
**What this does**: Currently doing `import postreise.analyze<TAB>` will autocomplete both `generation` and `generations` when running locally. This might cause an issue building the package.
**Time to review**: 1 min - just need to verify the folder structure.