### PR TITLE
fix: remove unused broken import

### DIFF
--- a/postreise/plot/plot_sim_vs_hist.py
+++ b/postreise/plot/plot_sim_vs_hist.py
@@ -2,8 +2,6 @@ import matplotlib.pyplot as plt
 import warnings
 import numpy as np
 
-from powersimdata.utility.constants import abv2state
-
 
 class PlotSettings:
     width = 0.3  # width of bars


### PR DESCRIPTION
## Purpose
This import is broken after powersimdata refactoring, but also unused now.

## Time to review
1 min. I found this after testing a notebook, since this file isn't used in automated tests. 