### PR TITLE
Add hover tool tips to Interconnections Map

### DIFF
--- a/postreise/plot/plot_interconnection_map.py
+++ b/postreise/plot/plot_interconnection_map.py
@@ -83,7 +83,7 @@ def map_interconnections(grid, hvdc_width=1, us_states_dat=us_states.data):
     )
 
     # for legend, hidden lines
-    leg_clr = ['#d8428d', '#0c84e2', '#6D3376' , '#012f56' ]
+    leg_clr = ["#d8428d", "#0c84e2", "#6D3376", "#012f56"]
     leg_lab = ["Western", "Eastern", "ERCOT", "HVDC"]
     leg_xs = [-1.084288e07] * 4
     leg_ys = [4.639031e06] * 4
@@ -104,7 +104,7 @@ def map_interconnections(grid, hvdc_width=1, us_states_dat=us_states.data):
         p.multi_line("xs", "ys", color=colr, line_width="capacity", source=source)
 
     lines = p.multi_line(
-        "xs", "ys", color='#012f56', line_width="capacity", source=multi_line_source4
+        "xs", "ys", color="#012f56", line_width="capacity", source=multi_line_source4
     )
     p.legend.location = "bottom_right"
 


### PR DESCRIPTION
**What the code is doing:** Add hover tool tips to interconnections map, showing the capacity of HVDC lines. Also includes some code refactoring, and adds the ability to scale up or down line thickness for HVDC branches.
**How long to review:** Half hour.
Note: My plan is to do a "rebase and merge" once this PR is approved, because the PR is just one commit.
Example: 
![Screen Shot 2020-08-17 at 10 54 37 AM](https://user-images.githubusercontent.com/49412554/90569587-ff084c80-e162-11ea-8a0c-670fb9b7a54b.png)
