### PR TITLE
refactor: expect datetime indices in tests with mock scenarios

### DIFF
--- a/postreise/analyze/generation/tests/test_binding.py
+++ b/postreise/analyze/generation/tests/test_binding.py
@@ -63,18 +63,16 @@ class TestRampConstraints(unittest.TestCase):
         grid_attrs = {"plant": mock_plant}
         mock_pg = pd.DataFrame(
             {
-                "UTC": ["t1", "t2", "t3", "t4"],
                 "A": [100, 104, (99 + 1e-4), (104 + 1e-4 - 1e-7)],
                 "B": [50, 45, 50, 45],
                 "C": [20, 40, 60, 80],
                 "D": [200, 150, 100, 50],
             }
         )
-        mock_pg.set_index("UTC", inplace=True)
         self.mock_scenario = MockScenario(grid_attrs, pg=mock_pg)
         self.default_expected = pd.DataFrame(
             {
-                "UTC": ["t1", "t2", "t3", "t4"],
+                "UTC": pd.date_range(start="2016-01-01", periods=4, freq="H"),
                 "A": [False, False, True, True],
                 "B": [False, False, False, False],
                 "C": [False, True, True, True],
@@ -101,7 +99,7 @@ class TestRampConstraints(unittest.TestCase):
         # One differece from test_ramp_constraints_default: ('A', 't3')
         binding_ramps = ramp_constraints(self.mock_scenario, epsilon=1e-6)
         expected = self.get_default_expected()
-        expected.loc["t3", "A"] = False
+        expected.loc["2016-01-01 02:00:00", "A"] = False
         assert binding_ramps.equals(expected)
 
     def test_ramp_constraints_spec_epsilon3(self):
@@ -121,18 +119,16 @@ class TestPminConstraints(unittest.TestCase):
         grid_attrs = {"plant": mock_plant}
         mock_pg = pd.DataFrame(
             {
-                "UTC": ["t1", "t2"],
                 "A": [0, 0],
                 "B": [(10 + 1e-4), 15],
                 "C": [25, (20 + 1e-7)],
                 "D": [35, 40],
             }
         )
-        mock_pg.set_index("UTC", inplace=True)
         self.mock_scenario = MockScenario(grid_attrs, pg=mock_pg)
         self.default_expected = pd.DataFrame(
             {
-                "UTC": ["t1", "t2"],
+                "UTC": pd.date_range(start="2016-01-01", periods=2, freq="H"),
                 "A": [True, True],
                 "B": [True, False],
                 "C": [False, True],
@@ -157,14 +153,14 @@ class TestPminConstraints(unittest.TestCase):
     def test_pmin_constraints_default_spec_epsilon2(self):
         binding_pmins = pmin_constraints(self.mock_scenario, epsilon=1e-6)
         expected = self.get_default_expected()
-        expected.loc["t1", "B"] = False
+        expected.loc["2016-01-01 00:00:00", "B"] = False
         assert binding_pmins.equals(expected)
 
     def test_pmin_constraints_default_spec_epsilon3(self):
         binding_pmins = pmin_constraints(self.mock_scenario, epsilon=1e-9)
         expected = self.get_default_expected()
-        expected.loc["t1", "B"] = False
-        expected.loc["t2", "C"] = False
+        expected.loc["2016-01-01 00:00:00", "B"] = False
+        expected.loc["2016-01-01 01:00:00", "C"] = False
         assert binding_pmins.equals(expected)
 
 
@@ -177,18 +173,16 @@ class TestPmaxConstraints(unittest.TestCase):
         grid_attrs = {"plant": mock_plant}
         mock_pg = pd.DataFrame(
             {
-                "UTC": ["t1", "t2"],
                 "A": [50, 50],
                 "B": [(75 - 1e-4), 70],
                 "C": [90, (100 - 1e-7)],
                 "D": [150, 175],
             }
         )
-        mock_pg.set_index("UTC", inplace=True)
         self.mock_scenario = MockScenario(grid_attrs, pg=mock_pg)
         self.default_expected = pd.DataFrame(
             {
-                "UTC": ["t1", "t2"],
+                "UTC": pd.date_range(start="2016-01-01", periods=2, freq="H"),
                 "A": [True, True],
                 "B": [True, False],
                 "C": [False, True],
@@ -213,12 +207,12 @@ class TestPmaxConstraints(unittest.TestCase):
     def test_pmax_constraints_default_sepc_epsilon2(self):
         binding_pmaxs = pmax_constraints(self.mock_scenario, epsilon=1e-6)
         expected = self.get_default_expected()
-        expected.loc["t1", "B"] = False
+        expected.loc["2016-01-01 00:00:00", "B"] = False
         assert binding_pmaxs.equals(expected)
 
     def test_pmax_constraints_default_sepc_epsilon3(self):
         binding_pmaxs = pmax_constraints(self.mock_scenario, epsilon=1e-9)
         expected = self.get_default_expected()
-        expected.loc["t1", "B"] = False
-        expected.loc["t2", "C"] = False
+        expected.loc["2016-01-01 00:00:00", "B"] = False
+        expected.loc["2016-01-01 01:00:00", "C"] = False
         assert binding_pmaxs.equals(expected)

--- a/postreise/analyze/generation/tests/test_curtailment.py
+++ b/postreise/analyze/generation/tests/test_curtailment.py
@@ -52,6 +52,8 @@ mock_curtailment_data = pd.DataFrame(
         "D": [0, 0, 1, 1.5],
     }
 )
+mock_curtailment_data["UTC"] = pd.date_range(start="2016-01-01", periods=4, freq="H")
+mock_curtailment_data.set_index("UTC", inplace=True)
 
 mock_curtailment = {
     "solar": mock_curtailment_data[["A", "B"]],

--- a/postreise/analyze/transmission/tests/test_congestion_surplus.py
+++ b/postreise/analyze/transmission/tests/test_congestion_surplus.py
@@ -43,7 +43,10 @@ class TestCalculateCongestionSurplus(unittest.TestCase):
             df.set_index("UTC", inplace=True)
         mock_scenario = MockScenario(grid_attrs, demand=demand, lmp=lmp, pg=pg)
 
-        expected_return = pd.Series(data=[787.5], index=["t1"])
+        expected_return = pd.Series(
+            data=[787.5],
+            index=pd.date_range(start="2016-01-01", periods=1, freq="H"),
+        )
         expected_return.rename_axis("UTC")
 
         surplus = calculate_congestion_surplus(mock_scenario)
@@ -74,7 +77,10 @@ class TestCalculateCongestionSurplus(unittest.TestCase):
             df.set_index("UTC", inplace=True)
         mock_scenario = MockScenario(grid_attrs, demand=demand, lmp=lmp, pg=pg)
 
-        expected_return = pd.Series(data=[787.5, 0, 0], index=time_indices)
+        expected_return = pd.Series(
+            data=[787.5, 0, 0],
+            index=pd.date_range(start="2016-01-01", periods=3, freq="H"),
+        )
         expected_return.rename_axis("UTC")
 
         surplus = calculate_congestion_surplus(mock_scenario)


### PR DESCRIPTION
Piggy-backing on the improvement of mock objects in https://github.com/Breakthrough-Energy/PowerSimData/pull/294, we need to refactor a few tests, so that they expect that the dataframes they get back will have time series indices. Tests will fail until https://github.com/Breakthrough-Energy/PowerSimData/pull/294 is merged in.