### PR TITLE
List of available resources

### DIFF
--- a/postreise/plot/analyze_pg.py
+++ b/postreise/plot/analyze_pg.py
@@ -5,7 +5,6 @@ import seaborn as sns
 import matplotlib.dates as mdates
 from pandas.plotting import scatter_matrix
 
-from postreise.analyze.helpers import get_resources_in_grid
 from powersimdata.network.usa_tamu.constants.plants import type2color, type2label
 
 
@@ -378,7 +377,7 @@ class AnalyzePG:
                     )
 
             t2l = type2label.copy()
-            for t in get_resources_in_grid(self.grid):
+            for t in type2label.keys():
                 if t not in pg_groups.columns:
                     del t2l[t]
 
@@ -505,7 +504,7 @@ class AnalyzePG:
                 ax = fig.gca()
 
             t2l = type2label.copy()
-            for t in get_resources_in_grid(self.grid):
+            for t in type2label.keys():
                 if t not in pg_stack.columns:
                     del t2l[t]
 


### PR DESCRIPTION
## Purpose
Fix a bug where the list of resources to plot is not correctly derived.

## What is the code doing?
The `get_resources_in_grid` function in `postreise.analyze.helpers` will never have `biomass` and `storage` in the return list. It follows that they won't be deleted from the `t2l` dictionary and an error will be raised afterwards

## Time estimate
3 min

## Test
the following script will fail before the fix:
```
from powersimdata.scenario.scenario import Scenario
from postreise.plot.analyze_pg import AnalyzePG as apg

start_date = '2016-02-12-00'
end_date = '2016-02-27-23'
interconnect = 'USA'
selected_resources = ['solar', 'wind']
zonelist = ['Chicago North Illinois']
s = Scenario('1242')
stack = apg(s,
            (start_date, end_date, 'utc', 'H'),
            zonelist,
            selected_resources,
            'stacked', normalize=False)
stack.get_plot(save=False)
```
![Figure_1](https://user-images.githubusercontent.com/16549571/93414570-6d215b80-f856-11ea-99a5-f824f9bb8620.png)
