### PR TITLE
State goals web map

### DIFF
--- a/postreise/plot/demo/plot_state_goals_map_demo.ipynb
+++ b/postreise/plot/demo/plot_state_goals_map_demo.ipynb
@@ -1,0 +1,164 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## US State RPS Goals Map with hover-over tool tips\n",
+    "author: vhunt\n",
+    "\n",
+    "updated with breakthrough energy compatible colors 9/23/2020"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bokeh.io import show\n",
+    "from postreise.plot import plot_carbon_map \n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#prepare data for mapping \n",
+    "\n",
+    "rps_states = ('AL', 'AR', 'AZ', 'CA', 'CO',\n",
+    "             'CT', 'DE', 'FL','GA', 'IA', \n",
+    "              'ID', 'IL', 'IN', 'KS', 'KY',\n",
+    "             'LA', 'MA', 'MD', 'ME', 'MI',\n",
+    "             'MN', 'MO', 'MS', 'MT', 'NC', \n",
+    "\n",
+    "             'ND', 'NE', 'NH','NJ','NM',\n",
+    "             'NV','NY', 'OH', 'OK','OR',\n",
+    "             'PA','RI','SC', 'SD','TN', \n",
+    "             'TX','UT', 'VA','VT', 'WA',\n",
+    "             'WI', 'WV','WY',)\n",
+    "\n",
+    "color_list = ('#EBEEF1','#EBEEF1','#99CFF6','#0D68DC','#1490FF',\n",
+    "              '#107CED','#1490FF','#EBEEF1','#EBEEF1', '#EBEEF1',\n",
+    "              '#EBEEF1','#1490FF','#99CFF6','#47AFFB','#EBEEF1',\n",
+    "              '#EBEEF1','#107CED','#107CED','#0A55CC','#107CED',\n",
+    "              '#1490FF','#99CFF6', '#EBEEF1', '#99CFF6', '#99CFF6',\n",
+    "              \n",
+    "              '#99CFF6','#EBEEF1','#1490FF','#107CED','#107CED',\n",
+    "              '#107CED', '#0D68DC','#99CFF6','#99CFF6','#1490FF',\n",
+    "              '#47AFFB','#107CED','#99CFF6','#99CFF6','#EBEEF1',\n",
+    "              '#107CED','#47AFFB','#99CFF6','#0A55CC','#0A55CC',\n",
+    "              '#99CFF6','#EBEEF1','#EBEEF1',\n",
+    "              )\n",
+    "\n",
+    "label_list = ('no clean energy goals', 'no clean energy goals',  '15% in 2025', \n",
+    "               '60% in 2030, 100% in 2045', '30% in 2020, 100% in 2050',\n",
+    "               '44% in 2025','25% in 2025','no clean energy goals', 'no clean energy goals', 'no clean energy goals',\n",
+    "               'no clean energy goals', '25% in 2025','10% in 2015','20% in 2020','no clean energy goals',\n",
+    "               'no clean energy goals', ' 35% in 2030','30% in 2020 and 50% in 2030', \n",
+    "               '80% in 2030, 100% in 2050','15% in 2020 and 35% in 2025',\n",
+    "               '25% in 2025','15% in 2020', 'no clean energy goals', '15% in 2020','12.5% in 2020',\n",
+    "                \n",
+    "               '10% in 2020','no clean energy goals','25% in 2025','50% in 2030',\n",
+    "               '40% in 2025, 80% in 2040, 100% in 2045',\n",
+    "               '50% in 2030, 100% in 2050', '70% in 2030, 100% in 2040', '8.5% in 2025', \n",
+    "               '15% in 2020','25% in 2025, 50% in 2040',\n",
+    "               '18% in 2020',\n",
+    "               '16% in 2020, 23.5% in 2025, 31% in 2030, 38.5% in 2035',\n",
+    "               '2% in 2020','10% in 2020', 'no clean energy goals',\n",
+    "               'no clean energy goals, projected to have 50% in 2030', '20% in 2035', \n",
+    "               '15% in 2025','55% in 2020, 75% in 2030', '80% in 2030, 100% in 2045',\n",
+    "               '10% in 2020', 'no clean energy goals', 'no clean energy goals',\n",
+    "               )\n",
+    "\n",
+    "data = {'State':  rps_states,\n",
+    "        'Color': color_list,\n",
+    "        'Label': label_list,\n",
+    "        }\n",
+    "\n",
+    "df = pd.DataFrame (data, columns = ['State','Color','Label'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#prepare data for legend\n",
+    "\n",
+    "legend_col = ['#EBEEF1',\n",
+    "              '#99CFF6', \n",
+    "              '#47AFFB',\n",
+    "              '#1490FF',\n",
+    "              '#107CED',\n",
+    "              '#0D68DC',\n",
+    "              '#0A55CC',\n",
+    "             ]\n",
+    "legend_lab = ['no goals',\n",
+    "              '0-15%', \n",
+    "              '15-20%',\n",
+    "              '20-30%',\n",
+    "              '30-50%',\n",
+    "              '50-70%',\n",
+    "              '70-100%',\n",
+    "             ]\n",
+    "\n",
+    "data_leg = {'Color':  legend_col,\n",
+    "            'Label': legend_lab,}\n",
+    "\n",
+    "df_leg = pd.DataFrame (data_leg, columns = ['Color','Label'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "goals_demo = plot_carbon_map.plot_states(state_list = df.State, \n",
+    "                           col_list = df.Color,\n",
+    "                           labels_list = df.Label,\n",
+    "                           leg_color = df_leg.Color,\n",
+    "                           leg_label = df_leg.Label,\n",
+    "                           font_size = '10pt',\n",
+    "                                         web = True)\n",
+    "show(goals_demo)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/postreise/plot/plot_carbon_map.py
+++ b/postreise/plot/plot_carbon_map.py
@@ -8,10 +8,11 @@ from bokeh.sampledata import us_states
 from postreise.plot.projection_helpers import project_bus
 from pyproj import Transformer
 
-# make default states list
+# make default states list, lower 48 only
 default_states_dict = us_states.data.copy()
 del default_states_dict["HI"]
 del default_states_dict["AK"]
+del default_states_dict["DC"]
 default_states_list = list(default_states_dict.keys())
 
 # breakthrough energy (be) color names
@@ -46,14 +47,26 @@ def get_borders(us_states_dat, state_list=None):
     return all_state_xs, all_state_ys
 
 
-def plot_states(state_list, col_list, labels_list, font_size, us_states_dat=None):
+def plot_states(
+    state_list,
+    col_list,
+    labels_list,
+    leg_color,
+    leg_label,
+    font_size,
+    web=True,
+    us_states_dat=None,
+):
     """Plots US state borders and allows color coding by state,
         for example to represent different emissions goals.
 
     :param list state_list: list of us states to color code.
     :param list col_list: list of colors associated with states in state_list.
     :param list labels_list: list of labels for us states.
-    :param float font_size: citation font size
+    :param list leg_color: list of colors for legend
+    :param list leg_label: list of labels for colors in legend
+    :param float font_size: citation font size, for non web version only
+    :param boolean web: if true, formats for website with hover tips
     :param dict us_states_dat: if None default to us_states data file, imported from bokeh.
     :return:  -- map of us states with option to color by value.
     """
@@ -68,31 +81,61 @@ def plot_states(state_list, col_list, labels_list, font_size, us_states_dat=None
 
     a, b = get_borders(us_states_dat.copy())
 
-    tools: str = "pan,wheel_zoom,reset,hover,save"
+    tools: str = "pan,wheel_zoom,reset,save"
     p = figure(
-        title="US States",
         tools=tools,
         x_axis_location=None,
         y_axis_location=None,
         plot_width=800,
         plot_height=800,
+        output_backend="webgl",
+        sizing_mode="stretch_both",
+        match_aspect=True,
     )
+
+    # legend squares, plot behind graph so hidden
+    for i in range(len(leg_color)):
+        p.square(
+            -8.1e6,
+            [5.2e6, 5.3e6],
+            fill_color=leg_color[i],
+            color=leg_color[i],
+            size=300,
+            legend_label=leg_label[i],
+        )
+
     p.add_tile(get_provider(Vendors.CARTODBPOSITRON_RETINA))
-    p.patches(a, b, fill_alpha=0, fill_color="blue", line_color="black", line_width=2)
-    # counter
+
+    # plot state borders
+    p.patches(a, b, fill_alpha=0, fill_color="blue", line_color="gray", line_width=2)
+
+    a1, b1 = get_borders(us_states_dat.copy(), state_list=state_list)
+    source = ColumnDataSource(
+        dict(
+            xs=a1,
+            ys=b1,
+            col=col_list,
+            col2=["gray" for i in range(48)],
+            label=labels_list,
+            state_name=state_list,
+        )
+    )
+
+    patch = p.patches(
+        "xs",
+        "ys",
+        source=source,
+        fill_alpha=0.8,
+        fill_color="col",
+        line_color="col2",
+    )
+
+    # loop through states and colors, plot patches
     n = -1
     # loop through states and colors, plot patches
     for i in state_list:
         n = n + 1
         a1, b1 = get_borders(us_states_dat.copy(), state_list=[i])
-        p.patches(
-            a1,
-            b1,
-            fill_alpha=0.8,
-            fill_color=[col_list[n]],
-            line_color="black",
-            line_width=2,
-        )
         citation = Label(
             x=min(a1[0]) + 100000,
             y=(max(b1[0]) + min(b1[0])) / 2,
@@ -106,7 +149,25 @@ def plot_states(state_list, col_list, labels_list, font_size, us_states_dat=None
             background_fill_color="white",
             background_fill_alpha=0.8,
         )
-        p.add_layout(citation)
+        if not web:
+            p.add_layout(citation)
+
+    # specify parameters if making figure for website
+    if web:
+        hover = HoverTool(
+            tooltips=[
+                ("State", "@state_name"),
+                ("Goal", "@label"),
+            ],
+            renderers=[patch],
+        )  # only for circles
+        p.add_tools(hover)
+
+    p.legend.title = "Goals up to 2030"
+    p.legend.location = "bottom_right"
+    p.legend.label_text_font_size = "12pt"
+
+    p.legend.title_text_font_size = "12pt"
     return p
 
 


### PR DESCRIPTION
[Pull Request Etiquette doc](https://github.com/Breakthrough-Energy/REISE/wiki/Pull-Request-Etiquette)

### Purpose
Make web compatible version of the RPS Goals map color coding US states by their goals and with hover-over tool tips to provide additional information. Relates to Zenhub #175 US States Goals Map: Update code and create demo notebook.

### What the code is doing
Demo notebook includes parameters used for the scrolly-telling version of the plot. Code plots US States color coded by goals and provides hover over tips for web version, or labels (citations) for ppt/presentation version.

### Testing
Manual testing.

### Where to look
Code lives in the plot_carbon_map.py. Demo notebook is with other demos in the demo folder and is new.

* What files are most important?
Plot_states function in Plot_carbon_map.py and the new demo: plot_state_goals_map_demo.ipynb

### Usage Example/Visuals
Web version:
![Screen Shot 2020-09-24 at 11 37 45 AM](https://user-images.githubusercontent.com/49412554/94185613-6009fb00-fe5a-11ea-9a8c-ff73db9f7a32.png)
Non-web/ ppt version:
![Screen Shot 2020-09-24 at 11 38 19 AM](https://user-images.githubusercontent.com/49412554/94185691-757f2500-fe5a-11ea-92d1-4b85c494a286.png)


### Time estimate
30 min. Not urgent. Code used for scrolly-telling page of website.