### PR TITLE
fix: typo in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = pytest, format
-skipdist = true
+skipsdist = true
 
 [testenv]
 passenv = 


### PR DESCRIPTION
### Purpose
Typo - `skipdist` is not a real tox config key so it's ignored, which means we are doing more installation than necessary.
Changed to the correct value - [reference](https://tox.readthedocs.io/en/latest/config.html#conf-skipsdist)

### Time to review
1 min - I tested locally by recreating the tox environment to make sure we actually save time by doing this