### PR TITLE
fix: wrong var name for mapper in map_risk_bind

### DIFF
--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -94,7 +94,7 @@ def map_risk_bind(risk_or_bind, congestion_stats, branch, us_states_dat=None):
         source=multi_line_source_all,
         alpha=0.5,
     )
-    p.multi_line("xs", "ys", color=mapper1, line_width="cap", source=multi_line_source)
+    p.multi_line("xs", "ys", color=mapper, line_width="cap", source=multi_line_source)
     return p
 
 


### PR DESCRIPTION
[Pull Request Etiquette doc](https://github.com/Breakthrough-Energy/REISE/wiki/Pull-Request-Etiquette)

### Purpose
Fixes a small bug in the risk / bind map. It had an incorrectly named variable so it was breaking.

### Testing
Generated some risk / bind maps to test manually.

### Time estimate
10 seconds or so