### PR TITLE
Renewable capacity map

### DIFF
--- a/postreise/plot/__init__.py
+++ b/postreise/plot/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "plot_energy_carbon_stack",
     "plot_interconnection_map",
     "plot_lmp_map",
+    "plot_renewable_capacity_map",
     "plot_shadowprice_map",
     "plot_sim_vs_hist",
     "plot_tornado",

--- a/postreise/plot/demo/plot_renewable_capacity_map_demo.ipynb
+++ b/postreise/plot/demo/plot_renewable_capacity_map_demo.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Map Renewable Capacity Additions: Renewables at Retirements Demo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One approach to reach clean energy goals would be to connect clean energy sources to existing transmission lines. Many power plants are reaching the end of their productive life or have become uneconomic in recent years. By siting clean energy sources near power plants that have been or will soon be shut down, we could have the joint benefit of reusing transmission infrastructure and aiding in an economic transition for the local communities. Such a strategy requires 30 percent fewer transmission upgrades to achieve clean energy goals across the U.S. by 2030.A map of renewable capacity added at retiring plants ('retirements') is available at https://science.breakthroughenergy.org/ for scenario 1244 (USA_2030_RARSCollaborative_OB3), as demonstrated below. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from postreise.plot import plot_renewable_capacity_map\n",
+    "from powersimdata.scenario.scenario import Scenario\n",
+    "from bokeh.io import show"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SCENARIO: Julia | USA_2030_RARSCollaborative_OB3\n",
+      "\n",
+      "--> State\n",
+      "analyze\n",
+      "--> Loading grid\n",
+      "--> Loading ct\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Load renewables at retirements scenario: USA_2030_RARSCollaborative_OB3\n",
+    "s1244 = Scenario('1244')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#make a map of renewables at retirements, where circle size indicates capacity added.\n",
+    "show(plot_renewable_capacity_map.map_plant_capacity(s1244))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/postreise/plot/plot_renewable_capacity_map.py
+++ b/postreise/plot/plot_renewable_capacity_map.py
@@ -1,0 +1,116 @@
+import pandas as pd
+from bokeh.models import ColumnDataSource, HoverTool
+from bokeh.plotting import figure
+from bokeh.sampledata import us_states
+from bokeh.tile_providers import Vendors, get_provider
+
+from postreise.analyze.check import _check_scenario_is_in_analyze_state
+from postreise.plot.plot_carbon_map import get_borders
+from postreise.plot.projection_helpers import project_bus
+
+# green, breakthrough energy colors (be)
+be_green = "#36D78C"
+
+
+def map_plant_capacity(
+    scenario,
+    us_states_dat=us_states.data,
+    size_factor=1,
+):
+    """Makes map of renewables from change table 'new plants'. Size/area
+        indicates capacity
+    :param powersimdata.scenario.scenario.Scenario scenario: scenario instance.
+    :param dict us_states_dat: us_states data file, imported from bokeh
+    :param float size_factor: scale size of glyphs
+    """
+
+    _check_scenario_is_in_analyze_state(scenario)
+
+    # prepare data from the change table to select new plants
+    ct = scenario.state.get_ct()
+    # check that there are new plants, check scenario is in analyze state
+    if "new_plant" not in ct.keys():
+        raise ValueError(
+            "There are no new plants added in the selected scenario. Please choose a different scenario."
+        )
+
+    newplant = pd.DataFrame(ct["new_plant"])
+    newplant = newplant.set_index("bus_id")
+    newplant = newplant[newplant.Pmax > 0]
+
+    # merge with bus info to get coordinates
+    gridscen = scenario.state.get_grid()
+    bus_of_interest = gridscen.bus.loc[list(set(newplant.index))]
+    bus_capacity = bus_of_interest.merge(newplant, right_index=True, left_index=True)
+
+    bus_map = project_bus(bus_capacity)
+    bus_map1 = bus_map.loc[bus_map.Pmax > 1]
+    rar_df = bus_map1.loc[(bus_map1.type_y == "solar") | (bus_map1.type_y == "wind")]
+
+    # group by coordinates
+    rar_df = rar_df.groupby(["lat", "lon"]).agg(
+        {"Pmax": "sum", "x": "mean", "y": "mean"}
+    )
+
+    a, b = get_borders(us_states_dat.copy())
+
+    rar_source = ColumnDataSource(
+        {
+            "x": rar_df["x"],
+            "y": rar_df["y"],
+            "capacity": (rar_df["Pmax"] * size_factor) ** 0.5,
+            "capacitymw": rar_df["Pmax"],
+        }
+    )
+
+    tools: str = "pan,wheel_zoom,reset,save"
+    p = figure(
+        tools=tools,
+        x_axis_location=None,
+        y_axis_location=None,
+        plot_width=800,
+        plot_height=800,
+        output_backend="webgl",
+        sizing_mode="stretch_both",
+        match_aspect=True,
+    )
+
+    # for legend, plot behind tiles
+    p.circle(
+        -8.1e6,
+        5.2e6,
+        fill_color=be_green,
+        color=be_green,
+        alpha=0.5,
+        size=50,
+        legend_label="Renewable Capacity Added",
+    )
+
+    p.add_tile(get_provider(Vendors.CARTODBPOSITRON_RETINA))
+
+    # state borders
+    p.patches(a, b, fill_alpha=0.0, line_color="gray", line_width=2)
+
+    # capacity circles
+    circle = p.circle(
+        "x",
+        "y",
+        fill_color=be_green,
+        color=be_green,
+        alpha=0.8,
+        size="capacity",
+        source=rar_source,
+    )
+    p.legend.label_text_font_size = "12pt"
+    p.legend.location = "bottom_right"
+
+    hover = HoverTool(
+        tooltips=[
+            ("Capacity (MW)", "@capacitymw"),
+        ],
+        renderers=[circle],
+    )
+
+    p.add_tools(hover)
+
+    return p


### PR DESCRIPTION
[Pull Request Etiquette doc](https://github.com/Breakthrough-Energy/REISE/wiki/Pull-Request-Etiquette)


### Purpose
Map plant capacity, used to show locations of renewables at retirements on scrolly-telling. Relates to Zenhub issue #177. This is basically a restart of PR 180, which i converted to a draft and then got reassigned to other things. There was a desire from the last review to add some pytest type testing to this, which i agree is needed in the long term. I am transitioning at this time to working 100% on the Catalyst project and so am trying to merge in my code quickly. Apologies that I didn't get to the pytests but at this point merging so the code is available for others to use for the dashboard and scrolly-telling is important so I am expediting this PR.

### What the code is doing
Code uses the change table from a scenario to identify new plants and then aggregates by coordinates, and maps the plant capacity for those new plants with circle size indicating capacity (pmax).

### Testing
manual testing

### Where to look
plot_renewable_capacity_map is the location of the function map_plant_capacity. Demo notebook has been added as well, plot_renewable_capacity_map_demo in the demo folder.

### Usage Example/Visuals
![image](https://user-images.githubusercontent.com/49412554/97644088-96610a00-1a06-11eb-84fc-178669c8d5c5.png)


### Time estimate
15 minutes. Code is very straightforward and very similar to carbon emissions plotting code. 