### PR TITLE
Add flake8 workflow and fix warnigns

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on: [push]
 
 jobs:
-  lint:
+  formatting:
     if: "!contains(github.event.head_commit.message, 'skip_ci')"
     runs-on: ubuntu-latest
     steps:
@@ -11,3 +11,11 @@ jobs:
       - uses: actions/setup-python@v2
       - run: python -m pip install --upgrade tox
       - run: tox -e checkformatting
+  flake8:
+    if: "!contains(github.event.head_commit.message, 'skip_ci')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: python -m pip install --upgrade tox
+      - run: tox -e flake8

--- a/postreise/analyze/generation/curtailment.py
+++ b/postreise/analyze/generation/curtailment.py
@@ -1,5 +1,4 @@
 import pandas as pd
-from powersimdata.network.usa_tamu.constants import zones
 from powersimdata.network.usa_tamu.constants.plants import renewable_resources
 
 from postreise.analyze.check import (

--- a/postreise/analyze/generation/emissions.py
+++ b/postreise/analyze/generation/emissions.py
@@ -8,8 +8,6 @@ from powersimdata.network.usa_tamu.constants.plants import (
     nox_per_mwh,
     so2_per_mwh,
 )
-from powersimdata.scenario.analyze import Analyze
-from powersimdata.scenario.scenario import Scenario
 
 from postreise.analyze.check import (
     _check_gencost,

--- a/postreise/analyze/generation/summarize.py
+++ b/postreise/analyze/generation/summarize.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 import numpy as np
 import pandas as pd
 from powersimdata.network.usa_tamu.constants.plants import type2label
@@ -11,7 +9,6 @@ from powersimdata.network.usa_tamu.constants.zones import (
     loadzone2state,
     state2loadzone,
 )
-from powersimdata.scenario.analyze import Analyze
 from powersimdata.scenario.scenario import Scenario
 
 from postreise.analyze.check import (

--- a/postreise/analyze/generation/tests/test_binding.py
+++ b/postreise/analyze/generation/tests/test_binding.py
@@ -90,7 +90,7 @@ class TestRampConstraints(unittest.TestCase):
     def test_ramp_constraints_default(self):
         binding_ramps = ramp_constraints(self.mock_scenario)
         expected = self.get_default_expected()
-        assert binding_ramps.equals(self.get_default_expected())
+        assert binding_ramps.equals(expected)
 
     def test_ramp_constraints_spec_epsilon1(self):
         # Same results as test_ramp_constraints_default

--- a/postreise/analyze/generation/tests/test_curtailment.py
+++ b/postreise/analyze/generation/tests/test_curtailment.py
@@ -127,7 +127,7 @@ class TestCalculateCurtailmentTimeSeries(unittest.TestCase):
 class TestCheckResourceInScenario(unittest.TestCase):
     def test_error_geothermal_curtailment(self):
         with self.assertRaises(ValueError):
-            curtailment = calculate_curtailment_time_series_by_resources(
+            calculate_curtailment_time_series_by_resources(
                 scenario, resources=("geothermal",)
             )
 
@@ -136,7 +136,7 @@ class TestCheckResourceInScenario(unittest.TestCase):
         no_solar_grid_attrs = {"plant": no_solar_mock_plant}
         no_solar_scenario = MockScenario(no_solar_grid_attrs)
         with self.assertRaises(ValueError):
-            curtailment = calculate_curtailment_time_series_by_resources(
+            calculate_curtailment_time_series_by_resources(
                 no_solar_scenario, resources=("solar",)
             )
 

--- a/postreise/analyze/generation/tests/test_summarize.py
+++ b/postreise/analyze/generation/tests/test_summarize.py
@@ -1,10 +1,8 @@
-import os
 import pathlib
 import unittest
 
 import pandas as pd
 import pytest
-from powersimdata.tests.mock_grid import MockGrid
 from powersimdata.tests.mock_scenario import MockScenario
 
 from postreise.analyze.generation.summarize import (

--- a/postreise/analyze/helpers.py
+++ b/postreise/analyze/helpers.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 
 import pandas as pd
-from powersimdata.input.grid import Grid
 from powersimdata.network.usa_tamu.constants import zones
 
 from postreise.analyze.check import (
@@ -173,7 +172,6 @@ def decompose_plant_data_frame_into_areas(df, areas, grid):
     _check_plants_are_in_grid(plant_id, grid)
     areas = _check_areas_are_in_grid_and_format(areas, grid)
 
-    plant = grid.plant
     df_areas = {}
     for k, v in areas.items():
         if k == "interconnect":

--- a/postreise/analyze/tests/test_helpers.py
+++ b/postreise/analyze/tests/test_helpers.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from powersimdata.input.grid import Grid
-from powersimdata.network.usa_tamu.constants import zones
 from powersimdata.tests.mock_grid import MockGrid
 
 from postreise.analyze.helpers import (

--- a/postreise/plot/multi/plot_bar.py
+++ b/postreise/plot/multi/plot_bar.py
@@ -40,7 +40,7 @@ def plot_bar(
     for zone in zone_list:
         ax_data_list = _construct_bar_ax_data(zone, graph_data, resource_types)
         _construct_bar_visuals(zone, ax_data_list)
-    print(f"\nDone\n")
+    print("\nDone\n")
 
 
 def plot_hbar(
@@ -80,7 +80,7 @@ def plot_hbar(
     for zone in zone_list:
         ax_data_list = _construct_bar_ax_data(zone, graph_data, resource_types)
         _construct_hbar_visuals(zone, ax_data_list)
-    print(f"\nDone\n")
+    print("\nDone\n")
 
 
 def _construct_bar_ax_data(zone, scenarios, user_set_resource_types):

--- a/postreise/plot/multi/plot_pie.py
+++ b/postreise/plot/multi/plot_pie.py
@@ -43,7 +43,7 @@ def plot_pie(
     for zone in zone_list:
         ax_data_list = _construct_pie_ax_data(zone, graph_data, min_percentage)
         _construct_pie_visuals(zone, ax_data_list)
-    print(f"\nDone\n")
+    print("\nDone\n")
 
 
 def _construct_pie_ax_data(zone, scenarios, min_percentage):

--- a/postreise/plot/multi/plot_shortfall.py
+++ b/postreise/plot/multi/plot_shortfall.py
@@ -77,7 +77,7 @@ def plot_shortfall(
         _construct_shortfall_visuals(
             zone, ax_data, shortfall_pct_list, is_match_CA, targets[zone], demand[zone]
         )
-    print(f"\nDone\n")
+    print("\nDone\n")
 
 
 def _construct_shortfall_ax_data(
@@ -191,7 +191,7 @@ def _construct_shortfall_data_for_western(
             if total_renewables <= baseline
             else shortfall
         )
-        print(f"\n\nWestern\n")
+        print("\n\nWestern\n")
         print(baseline, "|", total_renewables, "|", targets["Western"], "|", shortfall)
         ax_data.update(
             {

--- a/postreise/plot/multi/tests/test_plot_pie.py
+++ b/postreise/plot/multi/tests/test_plot_pie.py
@@ -79,4 +79,4 @@ def test_roll_up_small_pie_wedges_with_other_category():
         {"coal": 3, "solar": 1, "hydro": 4, "wind": 2}, 20
     )
     assert ax_data == {"coal": 3, "hydro": 4, "other": 3}
-    assert labels == ["Coal", "Hydro", f"Solar 10.0%\nWind 20.0%\n"]
+    assert labels == ["Coal", "Hydro", "Solar 10.0%\nWind 20.0%\n"]

--- a/postreise/plot/multi/tests/test_plot_shortfall.py
+++ b/postreise/plot/multi/tests/test_plot_shortfall.py
@@ -1,4 +1,3 @@
-from postreise.plot.multi.constants import ZONES
 from postreise.plot.multi.plot_shortfall import (
     _construct_shortfall_ax_data,
     _construct_shortfall_data_for_western,

--- a/postreise/plot/plot_lmp_map.py
+++ b/postreise/plot/plot_lmp_map.py
@@ -132,7 +132,7 @@ def _construct_shadowprice_visuals(lmp_split_points, bus_segments, us_states_dat
 
     hover = HoverTool(
         tooltips=[
-            (f"$/MWh", "@lmp{1.11}"),
+            ("$/MWh", "@lmp{1.11}"),
         ],
         renderers=[circle],
     )
@@ -179,7 +179,7 @@ def _construct_bus_legend(lmp_split_points):
     p.yaxis.ticker = list(labels.keys())
     p.yaxis.major_label_overrides = labels
 
-    p.text(x=[-0.05], y=[bar_len_sum * 1.01], text=[f" $/MWh"], text_font_size="12pt")
+    p.text(x=[-0.05], y=[bar_len_sum * 1.01], text=[" $/MWh"], text_font_size="12pt")
 
     return p
 

--- a/postreise/plot/plot_shadowprice_map.py
+++ b/postreise/plot/plot_shadowprice_map.py
@@ -288,7 +288,7 @@ def _construct_bus_legend(lmp_split_points):
     p.text(
         x=[-0.05],
         y=[bar_len_sum * 1.01],
-        text=[f"LMP ($/MWh)"],
+        text=["LMP ($/MWh)"],
         text_font_size="8pt",
         text_font_style="italic",
     )

--- a/postreise/plot/projection_helpers.py
+++ b/postreise/plot/projection_helpers.py
@@ -1,5 +1,3 @@
-import copy
-
 from pyproj import Transformer
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pytest, format
+envlist = pytest, format, flake8
 skipsdist = true
 
 [testenv]
@@ -10,6 +10,7 @@ deps =
     pytest: pipenv
     {format,checkformatting}: black
     {format,checkformatting}: isort
+    flake8: flake8
 commands =
     pytest: pipenv sync --dev
     pytest: pytest
@@ -17,3 +18,7 @@ commands =
     format: isort -m 3 --tc .
     checkformatting: black . --check --diff
     checkformatting: isort -m 3 --tc --check --diff .
+    flake8: flake8 postreise/
+
+[flake8]
+ignore = E501,W503,E203,E741


### PR DESCRIPTION
### Purpose
Duplicate the flake8 setup we have in powersimdata

### What the code is doing
Add flake8 to default tox workflows, add job to the lint workflow (github action), fix warnings. 

### Testing
Ran tox

### Time estimate
5 min - the setup is copied from powersimdata, most of the fixes are unused imports/variables