### PR TITLE
feat: add option to create bokeh figures for the website

### DIFF
--- a/postreise/plot/plot_lmp_map.py
+++ b/postreise/plot/plot_lmp_map.py
@@ -12,7 +12,7 @@ from bokeh.tile_providers import Vendors, get_provider
 from postreise.plot.projection_helpers import project_borders, project_bus
 
 
-def map_lmp(s_grid, lmp, us_states_dat=None, lmp_min=20, lmp_max=45):
+def map_lmp(s_grid, lmp, us_states_dat=None, lmp_min=20, lmp_max=45, is_website=False):
     """Plots average LMP by color coding buses
 
     :param powersimdata.input.grid.Grid s_grid: scenario grid
@@ -20,6 +20,7 @@ def map_lmp(s_grid, lmp, us_states_dat=None, lmp_min=20, lmp_max=45):
     :param dict us_states_dat: if None default to us_states data file, imported from bokeh
     :param inf/float lmp_min: minimum LMP to clamp plot range to.
     :param inf/float lmp_max: maximum LMP to clamp plot range to.
+    :param bool is_website: changes text/legend formatting to look better on the website
     :return: (*bokeh.models.layout.Row*) bokeh map visual in row layout
     """
     if us_states_dat is None:
@@ -27,7 +28,9 @@ def map_lmp(s_grid, lmp, us_states_dat=None, lmp_min=20, lmp_max=45):
 
     bus = project_bus(s_grid.bus)
     bus_segments = _construct_bus_data(bus, lmp, lmp_min, lmp_max)
-    return _construct_shadowprice_visuals(bus_segments, us_states_dat, lmp_min, lmp_max)
+    return _construct_shadowprice_visuals(
+        bus_segments, us_states_dat, lmp_min, lmp_max, is_website
+    )
 
 
 def _construct_bus_data(bus_map, lmp, lmp_min, lmp_max):
@@ -75,7 +78,9 @@ def group_lat_lon(bus_map):
     return bus_map2
 
 
-def _construct_shadowprice_visuals(bus_segments, us_states_dat, lmp_min, lmp_max):
+def _construct_shadowprice_visuals(
+    bus_segments, us_states_dat, lmp_min, lmp_max, is_website=False
+):
     """Uses bokeh to plot formatted data. Make map showing lmp using color.
 
     :param list(pandas.DataFrame) bus_segments: bus data split by lmp
@@ -83,6 +88,7 @@ def _construct_shadowprice_visuals(bus_segments, us_states_dat, lmp_min, lmp_max
     :param str file_name: name for output png file
     :param inf/float lmp_min: minimum LMP to clamp plot range to.
     :param inf/float lmp_max: maximum LMP to clamp plot range to.
+    :param bool is_website: changes text/legend formatting to look better on the website
     :return: (*bokeh.models.layout.Row*) bokeh map visual in row layout
     """
 
@@ -126,15 +132,16 @@ def _construct_shadowprice_visuals(bus_segments, us_states_dat, lmp_min, lmp_max
     )
     p.add_tools(hover)
     # Add legend
-    bus_legend = _construct_bus_legend(lmp_min, lmp_max)
-    return row(bus_legend, p)
+    bus_legend = _construct_bus_legend(lmp_min, lmp_max, is_website)
+    return row(bus_legend, p, sizing_mode="stretch_both")
 
 
-def _construct_bus_legend(lmp_min, lmp_max):
+def _construct_bus_legend(lmp_min, lmp_max, is_website=False):
     """Constructs the legend for lmp at each bus
 
     :param inf/float lmp_min: minimum LMP to clamp plot range to.
     :param inf/float lmp_max: maximum LMP to clamp plot range to.
+    :param bool is_website: changes text/legend formatting to look better on the website
     :return: (bokeh.plotting.figure) the legend showing lmp for each bus
     """
     x_range = [""]
@@ -146,10 +153,12 @@ def _construct_bus_legend(lmp_min, lmp_max):
     p = figure(
         x_range=x_range,
         plot_height=800,
-        plot_width=110,
+        plot_width=50 if is_website else 110,
         toolbar_location=None,
         tools="",
         output_backend="webgl",
+        sizing_mode="stretch_height",
+        match_aspect=True,
     )
     p.vbar_stack(
         list(bars.keys())[1:],
@@ -164,10 +173,27 @@ def _construct_bus_legend(lmp_min, lmp_max):
     p.xgrid.grid_line_color = None
     p.axis.minor_tick_line_color = None
     p.outline_line_color = None
-    p.yaxis.ticker = list(labels.keys())
+    ticker_vals = list(labels.keys())
+    # Label colorbar in increments of 5 for website
+    p.yaxis.ticker = ticker_vals[0::5] if is_website else ticker_vals
     p.yaxis.major_label_overrides = labels
 
-    p.text(x=[-0.05], y=[bar_len_sum * 1.01], text=[" $/MWh"], text_font_size="12pt")
+    if is_website:
+        # Prevents $/MWh text from being cut off
+        p.rect(
+            x=0,
+            y=bar_len_sum + 7,
+            width=1,
+            height=7,
+            alpha=0,
+        )
+    p.text(
+        x=[0.05],
+        y=[bar_len_sum * 1.01],
+        text=["$/\nMWh" if is_website else " $/MWh"],
+        text_font_size="7pt" if is_website else "12pt",
+        level="overlay",
+    )
 
     return p
 
@@ -197,9 +223,10 @@ def _get_bus_legend_bars_and_labels(x_range, lmp_min, lmp_max):
             # Min bar length of 1 to ensure small bars are visible
             bar_length = max(1, round(lmp_diff, 1))
 
-        labels[round(bar_length_sum, -1)] = str(
+        label_num = int(
             round(((lmp_split_points[i] - 1) * (lmp_max - lmp_min) / 256 + lmp_min), 0)
         )
+        labels[round(bar_length_sum, -1)] = str(label_num)
         if i != len(lmp_split_points) - 1:
             bars[str(i)] = [bar_length]
             bar_length_sum += bar_length

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -28,7 +28,13 @@ traffic_palette = [
 
 
 def map_risk_bind(
-    risk_or_bind, congestion_stats, branch, us_states_dat=None, vmin=None, vmax=None
+    risk_or_bind,
+    congestion_stats,
+    branch,
+    us_states_dat=None,
+    vmin=None,
+    vmax=None,
+    is_website=False,
 ):
     """Makes map showing risk or binding incidents on US states map.
 
@@ -41,6 +47,7 @@ def map_risk_bind(
         If None, default to bokeh.sampledata.us_states.
     :param int/float vmin: minimum value for color range. If None, use data minimum.
     :param int/float vmax: maximum value for color range. If None, use data maximum.
+    :param bool is_website: changes text/legend formatting to look better on the website
     :return:  -- map of lines with risk and bind incidents color coded
     """
     if us_states_dat is None:
@@ -77,7 +84,7 @@ def map_risk_bind(
     )
     color_bar = ColorBar(
         color_mapper=mapper["transform"],
-        width=500,
+        width=385 if is_website else 500,
         height=5,
         location=(0, 0),
         title=risk_or_bind_units,
@@ -131,7 +138,9 @@ def map_risk_bind(
     return p
 
 
-def map_utilization(utilization_df, branch, us_states_dat=None, vmin=None, vmax=None):
+def map_utilization(
+    utilization_df, branch, us_states_dat=None, vmin=None, vmax=None, is_website=False
+):
     """Makes map showing utilization. Utilization input can either be medians
     only, or can be normalized utilization dataframe
 
@@ -143,6 +152,7 @@ def map_utilization(utilization_df, branch, us_states_dat=None, vmin=None, vmax=
         If None, default to bokeh.sampledata.us_states.
     :param int/float vmin: minimum value for color range. If None, use data minimum.
     :param int/float vmax: maximum value for color range. If None, use data maximum.
+    :param bool is_website: changes text/legend formatting to look better on the website
     :return:  -- map of lines with median utilization color coded
     """
     if us_states_dat is None:
@@ -167,7 +177,7 @@ def map_utilization(utilization_df, branch, us_states_dat=None, vmin=None, vmax=
 
     color_bar = ColorBar(
         color_mapper=mapper1["transform"],
-        width=500,
+        width=385 if is_website else 500,
         height=5,
         location=(0, 0),
         title="median utilization",


### PR DESCRIPTION
[Pull Request Etiquette doc](https://github.com/Breakthrough-Energy/REISE/wiki/Pull-Request-Etiquette)

### Purpose
Previously when generating bokeh graphs for the website, I was using my own branch of PostREISE with modified graph code. Because of that, nobody else could really make the bokeh graphs, so I'm fixing that issue here.

Bonus: I'm using this code to update all the bokeh graphs for the website :) 

### What the code is doing
Adds an `is_website` flag to the transmission and LMP graphs. When this flag is set to True, it changes some small things such as text size and legend width.

### Testing
Visual confirmation

### Usage Example/Visuals
Simply invoke the plotting code as usual, but set the is_website flag to True. Omitting the flag defaults to False.
`map_lmp(grid, lmp, is_website=True)`

Some maps on the website dashboard:
![Screen Shot 2021-01-12 at 1 24 20 AM](https://user-images.githubusercontent.com/16725791/104295223-0105db80-5475-11eb-9231-474d3aa2955b.png)
![Screen Shot 2021-01-12 at 1 24 53 AM](https://user-images.githubusercontent.com/16725791/104295231-03683580-5475-11eb-976f-5063fe68fc75.png)

### Time estimate
Maybe 10-15 mins. Not urgent though.