### PR TITLE
refactor: remove seaborn dependency for colors

### DIFF
--- a/postreise/plot/multi/constants.py
+++ b/postreise/plot/multi/constants.py
@@ -1,5 +1,3 @@
-import seaborn as sns
-
 ZONES = {
     "Western": [
         "Arizona",
@@ -53,18 +51,18 @@ RESOURCE_LABELS = {
     "biomass": "Biomass",
 }
 RESOURCE_COLORS = {
-    "wind": sns.xkcd_rgb["green"],
-    "solar": sns.xkcd_rgb["amber"],
-    "hydro": sns.xkcd_rgb["light blue"],
-    "ng": sns.xkcd_rgb["orchid"],
-    "nuclear": sns.xkcd_rgb["silver"],
-    "coal": sns.xkcd_rgb["light brown"],
-    "geothermal": sns.xkcd_rgb["hot pink"],
-    "dfo": sns.xkcd_rgb["royal blue"],
-    "storage": sns.xkcd_rgb["orange"],
+    "wind": "xkcd:green",
+    "solar": "xkcd:amber",
+    "hydro": "xkcd:light blue",
+    "ng": "xkcd:orchid",
+    "nuclear": "xkcd:silver",
+    "coal": "xkcd:light brown",
+    "geothermal": "xkcd:hot pink",
+    "dfo": "xkcd:royal blue",
+    "storage": "xkcd:orange",
     "other inc. biomass": "rebeccapurple",
-    "other": sns.xkcd_rgb["melon"],
-    "biomass": sns.xkcd_rgb["dark green"],
+    "other": "xkcd:melon",
+    "biomass": "xkcd:dark green",
 }
 SHADOW_PRICE_COLORS = [
     "darkmagenta",


### PR DESCRIPTION
### Purpose
Remove seaborn dependency for colors.

### What the code is doing
Instead of importing `seaborn` to access the xkcd colors for resources, specify as `"xkcd:*"` strings directly, since the only time they are used is in **postreise/plot/multi/plot_bar.py** which passes them to matplotlib and matplotlib knows how to interpret those strings. See https://github.com/Breakthrough-Energy/PowerSimData/pull/145

### Time estimate
5 minutes.