### PR TITLE
refactor: remove redundant map_demand_to_buses

### DIFF
--- a/postreise/analyze/transmission/congestion.py
+++ b/postreise/analyze/transmission/congestion.py
@@ -1,41 +1,10 @@
 import numpy as np
 import pandas as pd
-from powersimdata.input.grid import Grid
+from powersimdata.input.input_data import get_bus_demand
 from powersimdata.scenario.analyze import Analyze
 from powersimdata.scenario.scenario import Scenario
 
 from postreise.analyze.helpers import summarize_plant_to_bus
-
-
-def map_demand_to_buses(grid, demand):
-    """Map demand by (hour, zone) to (hour, bus).
-
-    :param powersimdata.input.grid.Grid grid: Grid instance.
-    :param pandas.DataFrame demand: demand DataFrame.
-    :return: (*pandas.DataFrame*) -- bus_demand, indices (hour, bus).
-    """
-
-    if not isinstance(grid, Grid):
-        raise TypeError("grid must be a Grid object")
-    if not isinstance(demand, pd.DataFrame):
-        raise TypeError("demand must be a pandas DataFrame")
-
-    bus = grid.bus
-    zones = list(grid.id2zone.keys())
-    bus_demands = {}
-    for z in zones:
-        # Calculate share of zone demand to each zone bus
-        zone_buses = bus[bus["zone_id"] == z]
-        load_sum = zone_buses["Pd"].sum()
-        load_ratio = zone_buses["Pd"] / load_sum
-        # Then distribute time-series demand to buses
-        bus_demands[z] = pd.DataFrame(
-            data=np.outer(demand[z].to_numpy(), load_ratio.to_numpy()),
-            columns=load_ratio.index,
-            index=demand.index,
-        )
-    bus_demand = pd.concat([bus_demands[z] for z in zones], axis=1)
-    return bus_demand
 
 
 def calculate_congestion_surplus(scenario):
@@ -50,12 +19,11 @@ def calculate_congestion_surplus(scenario):
     if not isinstance(scenario.state, Analyze):
         raise ValueError("scenario.state must be Analyze")
 
-    demand = scenario.state.get_demand(original=False)
     grid = scenario.state.get_grid()
     lmp = scenario.state.get_lmp()
     pg = scenario.state.get_pg()
 
-    bus_demand = map_demand_to_buses(grid, demand).to_numpy()
+    bus_demand = get_bus_demand(scenario.info, grid).to_numpy()
     bus_pg = summarize_plant_to_bus(pg, grid, all_buses=True)
 
     congestion_surplus = (lmp.to_numpy() * (bus_demand - bus_pg)).sum(axis=1)

--- a/postreise/analyze/transmission/tests/test_congestion_surplus.py
+++ b/postreise/analyze/transmission/tests/test_congestion_surplus.py
@@ -2,13 +2,9 @@ import unittest
 
 import numpy as np
 import pandas as pd
-from powersimdata.tests.mock_grid import MockGrid
 from powersimdata.tests.mock_scenario import MockScenario
 
-from postreise.analyze.transmission.congestion import (
-    calculate_congestion_surplus,
-    map_demand_to_buses,
-)
+from postreise.analyze.transmission import congestion
 
 mock_plant = {
     "plant_id": ["A", "B", "C", "D"],
@@ -49,7 +45,7 @@ class TestCalculateCongestionSurplus(unittest.TestCase):
         )
         expected_return.rename_axis("UTC")
 
-        surplus = calculate_congestion_surplus(mock_scenario)
+        surplus = congestion.calculate_congestion_surplus(mock_scenario)
         self._check_return(expected_return, surplus)
 
     def test_calculate_congestion_surplus_three_times(self):
@@ -83,30 +79,5 @@ class TestCalculateCongestionSurplus(unittest.TestCase):
         )
         expected_return.rename_axis("UTC")
 
-        surplus = calculate_congestion_surplus(mock_scenario)
+        surplus = congestion.calculate_congestion_surplus(mock_scenario)
         self._check_return(expected_return, surplus)
-
-
-class TestMappingHelpers(unittest.TestCase):
-    def _check_expected(self, test_return, expected_return, name):
-        self.assertIsInstance(test_return, pd.DataFrame)
-        msg = "Index mismatch for " + name
-        np.testing.assert_array_equal(test_return.index, expected_return.index, msg)
-        msg = "Column mismatch for " + name
-        np.testing.assert_array_equal(test_return.columns, expected_return.columns, msg)
-        msg = "Values mismatch for " + name
-        np.testing.assert_array_almost_equal(
-            test_return.to_numpy(), expected_return.to_numpy(), err_msg=msg
-        )
-
-    def test_map_demand_to_buses(self):
-        grid = MockGrid(grid_attrs)
-        demand = pd.DataFrame({"UTC": ["t1", "t2"], 1: [410] * 2, 2: [0] * 2})
-        demand.set_index("UTC", inplace=True)
-        expected_return = pd.DataFrame(
-            {"UTC": ["t1", "t2"], 1: [50] * 2, 2: [60] * 2, 3: [300] * 2}
-        )
-        expected_return.set_index("UTC", inplace=True)
-
-        bus_demand = map_demand_to_buses(grid, demand)
-        self._check_expected(bus_demand, expected_return, name="bus_demand")

--- a/postreise/analyze/transmission/tests/test_congestion_surplus.py
+++ b/postreise/analyze/transmission/tests/test_congestion_surplus.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 import pandas as pd
 from powersimdata.tests.mock_scenario import MockScenario
@@ -18,66 +16,65 @@ mock_bus = {
 grid_attrs = {"plant": mock_plant, "bus": mock_bus}
 
 
-class TestCalculateCongestionSurplus(unittest.TestCase):
-    def _check_return(self, expected_return, surplus):
-        self.assertIsInstance(surplus, pd.Series)
-        msg = "Time series indices don't match"
-        np.testing.assert_array_equal(
-            surplus.index.to_numpy(), expected_return.index.to_numpy(), msg
-        )
-        msg = "Values don't match expected"
-        np.testing.assert_array_equal(
-            surplus.to_numpy(), expected_return.to_numpy(), msg
-        )
+def _check_return(expected_return, surplus):
+    assert isinstance(surplus, pd.Series)
+    msg = "Time series indices don't match"
+    np.testing.assert_array_equal(
+        surplus.index.to_numpy(), expected_return.index.to_numpy(), msg
+    )
+    msg = "Values don't match expected"
+    np.testing.assert_array_equal(surplus.to_numpy(), expected_return.to_numpy(), msg)
 
-    def test_calculate_congestion_surplus_single_time(self):
-        """Congested case from Kirschen & Strbac Section 5.3.2.4"""
-        demand = pd.DataFrame({"UTC": ["t1"], 1: [410], 2: [0]})
-        lmp = pd.DataFrame({"UTC": ["t1"], 1: [7.5], 2: [11.25], 3: [10]})
-        pg = pd.DataFrame({"UTC": ["t1"], "A": [50], "B": [285], "C": [0], "D": [75]})
-        for df in (demand, lmp, pg):
-            df.set_index("UTC", inplace=True)
-        mock_scenario = MockScenario(grid_attrs, demand=demand, lmp=lmp, pg=pg)
 
-        expected_return = pd.Series(
-            data=[787.5],
-            index=pd.date_range(start="2016-01-01", periods=1, freq="H"),
-        )
-        expected_return.rename_axis("UTC")
+def test_calculate_congestion_surplus_single_time():
+    """Congested case from Kirschen & Strbac Section 5.3.2.4"""
+    demand = pd.DataFrame({"UTC": ["t1"], 1: [410], 2: [0]})
+    lmp = pd.DataFrame({"UTC": ["t1"], 1: [7.5], 2: [11.25], 3: [10]})
+    pg = pd.DataFrame({"UTC": ["t1"], "A": [50], "B": [285], "C": [0], "D": [75]})
+    for df in (demand, lmp, pg):
+        df.set_index("UTC", inplace=True)
+    mock_scenario = MockScenario(grid_attrs, demand=demand, lmp=lmp, pg=pg)
 
-        surplus = congestion.calculate_congestion_surplus(mock_scenario)
-        self._check_return(expected_return, surplus)
+    expected_return = pd.Series(
+        data=[787.5],
+        index=pd.date_range(start="2016-01-01", periods=1, freq="H"),
+    )
+    expected_return.rename_axis("UTC")
 
-    def test_calculate_congestion_surplus_three_times(self):
-        """First: congested. Second: uncongested. Third: uncongested, fuzzy."""
-        time_indices = ["t1", "t2", "t3"]
-        demand = pd.DataFrame({"UTC": time_indices, 1: [410] * 3, 2: [0] * 3})
-        lmp = pd.DataFrame(
-            {
-                "UTC": time_indices,
-                1: [7.5, 7.5, 7.5],
-                2: [11.25, 7.5, 7.5],
-                3: [10, 7.5, 7.49],
-            }
-        )
-        pg = pd.DataFrame(
-            {
-                "UTC": time_indices,
-                "A": [50, 125, 125],
-                "B": [285] * 3,
-                "C": [0] * 3,
-                "D": [75, 0, 0],
-            }
-        )
-        for df in (demand, lmp, pg):
-            df.set_index("UTC", inplace=True)
-        mock_scenario = MockScenario(grid_attrs, demand=demand, lmp=lmp, pg=pg)
+    surplus = congestion.calculate_congestion_surplus(mock_scenario)
+    _check_return(expected_return, surplus)
 
-        expected_return = pd.Series(
-            data=[787.5, 0, 0],
-            index=pd.date_range(start="2016-01-01", periods=3, freq="H"),
-        )
-        expected_return.rename_axis("UTC")
 
-        surplus = congestion.calculate_congestion_surplus(mock_scenario)
-        self._check_return(expected_return, surplus)
+def test_calculate_congestion_surplus_three_times():
+    """First: congested. Second: uncongested. Third: uncongested, fuzzy."""
+    time_indices = ["t1", "t2", "t3"]
+    demand = pd.DataFrame({"UTC": time_indices, 1: [410] * 3, 2: [0] * 3})
+    lmp = pd.DataFrame(
+        {
+            "UTC": time_indices,
+            1: [7.5, 7.5, 7.5],
+            2: [11.25, 7.5, 7.5],
+            3: [10, 7.5, 7.49],
+        }
+    )
+    pg = pd.DataFrame(
+        {
+            "UTC": time_indices,
+            "A": [50, 125, 125],
+            "B": [285] * 3,
+            "C": [0] * 3,
+            "D": [75, 0, 0],
+        }
+    )
+    for df in (demand, lmp, pg):
+        df.set_index("UTC", inplace=True)
+    mock_scenario = MockScenario(grid_attrs, demand=demand, lmp=lmp, pg=pg)
+
+    expected_return = pd.Series(
+        data=[787.5, 0, 0],
+        index=pd.date_range(start="2016-01-01", periods=3, freq="H"),
+    )
+    expected_return.rename_axis("UTC")
+
+    surplus = congestion.calculate_congestion_surplus(mock_scenario)
+    _check_return(expected_return, surplus)


### PR DESCRIPTION
### Purpose
- Remove redundant function which gets bus demand. See performance comparison in https://github.com/Breakthrough-Energy/PowerSimData/pull/388.
- Refactor the congestion surplus tests from `unittest` to `pytest` to get to `monkeypatch` functionality (& general succinctness)
- Refactor test of congestion surplus calculation to monkeypatch around the `InputData.get_data` method which relies on profile CSVs. (see https://docs.pytest.org/en/stable/monkeypatch.html)

### Time estimate
10 minutes, mostly for understanding the test changes.