### PR TITLE
ci: use built in black profile for isort

### DIFF
--- a/postreise/analyze/generation/binding.py
+++ b/postreise/analyze/generation/binding.py
@@ -1,7 +1,4 @@
-from postreise.analyze.check import (
-    _check_epsilon,
-    _check_scenario_is_in_analyze_state,
-)
+from postreise.analyze.check import _check_epsilon, _check_scenario_is_in_analyze_state
 
 
 def pmin_constraints(scenario, epsilon=1e-3):

--- a/postreise/analyze/generation/tests/test_binding.py
+++ b/postreise/analyze/generation/tests/test_binding.py
@@ -3,10 +3,7 @@ import unittest
 import pandas as pd
 from powersimdata.tests.mock_scenario import MockScenario
 
-from postreise.analyze.check import (
-    _check_epsilon,
-    _check_scenario_is_in_analyze_state,
-)
+from postreise.analyze.check import _check_epsilon, _check_scenario_is_in_analyze_state
 from postreise.analyze.generation.binding import (
     pmax_constraints,
     pmin_constraints,

--- a/postreise/analyze/tests/test_demand.py
+++ b/postreise/analyze/tests/test_demand.py
@@ -2,10 +2,7 @@ import pandas as pd
 from numpy.testing import assert_array_equal
 from powersimdata.tests.mock_scenario import MockScenario
 
-from postreise.analyze.demand import (
-    get_demand_time_series,
-    get_net_demand_time_series,
-)
+from postreise.analyze.demand import get_demand_time_series, get_net_demand_time_series
 
 mock_plant = {
     "plant_id": ["1001", "1002", "1003"],

--- a/postreise/analyze/time.py
+++ b/postreise/analyze/time.py
@@ -1,10 +1,7 @@
 import pandas as pd
 import pytz
 
-from postreise.analyze.check import (
-    _check_date_range_in_time_series,
-    _check_time_series,
-)
+from postreise.analyze.check import _check_date_range_in_time_series, _check_time_series
 
 
 def slice_time_series(ts, start, end):

--- a/postreise/plot/analyze_pg.py
+++ b/postreise/plot/analyze_pg.py
@@ -4,10 +4,7 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from pandas.plotting import scatter_matrix
-from powersimdata.network.usa_tamu.constants.plants import (
-    type2color,
-    type2label,
-)
+from powersimdata.network.usa_tamu.constants.plants import type2color, type2label
 
 plt.ioff()
 

--- a/postreise/plot/plot_curtailment_ts.py
+++ b/postreise/plot/plot_curtailment_ts.py
@@ -2,19 +2,14 @@ import os
 
 import matplotlib.pyplot as plt
 import pandas as pd
-from powersimdata.network.usa_tamu.constants.plants import (
-    type2color,
-    type2label,
-)
+from powersimdata.network.usa_tamu.constants.plants import type2color, type2label
 
 from postreise.analyze.check import (
     _check_resources_and_format,
     _check_scenario_is_in_analyze_state,
 )
 from postreise.analyze.demand import get_demand_time_series
-from postreise.analyze.generation.curtailment import (
-    get_curtailment_time_series,
-)
+from postreise.analyze.generation.curtailment import get_curtailment_time_series
 from postreise.analyze.generation.summarize import (
     get_generation_time_series_by_resources,
 )

--- a/postreise/plot/plot_generation_ts_stack.py
+++ b/postreise/plot/plot_generation_ts_stack.py
@@ -10,17 +10,12 @@ from powersimdata.network.usa_tamu.constants.plants import (
 )
 
 from postreise.analyze.check import _check_scenario_is_in_analyze_state
-from postreise.analyze.demand import (
-    get_demand_time_series,
-    get_net_demand_time_series,
-)
+from postreise.analyze.demand import get_demand_time_series, get_net_demand_time_series
 from postreise.analyze.generation.capacity_value import (
     get_capacity_by_resources,
     get_storage_capacity,
 )
-from postreise.analyze.generation.curtailment import (
-    get_curtailment_time_series,
-)
+from postreise.analyze.generation.curtailment import get_curtailment_time_series
 from postreise.analyze.generation.summarize import (
     get_generation_time_series_by_resources,
     get_storage_time_series,

--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,13 @@ commands =
     pytest: pipenv sync --dev
     pytest: pytest
     format: black .
-    format: isort -m 3 --tc .
+    format: isort .
     checkformatting: black . --check --diff
-    checkformatting: isort -m 3 --tc --check --diff .
+    checkformatting: isort --check --diff .
     flake8: flake8 postreise/
 
 [flake8]
 ignore = E501,W503,E203,E741
+
+[isort]
+profile = black


### PR DESCRIPTION
### Purpose
We can take advantage of isort's built in "profile" for black compatibility. This includes a line length option which we were msising, along with a couple others I'm not sure about. [Source](https://github.com/PyCQA/isort/blob/develop/isort/profiles.py) from their repo is easy to read.

### What the code is doing
Added isort section in tox.ini

### Testing
Ran `tox -e format` locally, and ci passes.

### Time estimate
5 min