### PR TITLE
ci: add pep8-naming check to flake8

### DIFF
--- a/postreise/analyze/generation/capacity_value.py
+++ b/postreise/analyze/generation/capacity_value.py
@@ -9,7 +9,7 @@ from postreise.analyze.helpers import (
 )
 
 
-def calculate_NLDC(scenario, resources, hours=100):
+def calculate_NLDC(scenario, resources, hours=100):  # noqa: N802
     """Calculate the capacity value of a class of resources by comparing the
     mean of the top N hour of absolute demand to the mean of the top N hours of
     net demand. NLDC = 'Net Load Duration Curve'.

--- a/postreise/analyze/generation/tests/test_capacity_value.py
+++ b/postreise/analyze/generation/tests/test_capacity_value.py
@@ -129,35 +129,35 @@ scenario.state.grid.zone2id = {
 }
 
 
-def test_NLDC_calculation_wind_str():
+def test_NLDC_calculation_wind_str():  # noqa: N802
     assert calculate_NLDC(scenario, "wind", 10) == approx(3496.1)
 
 
-def test_NLDC_calculation_wind_set():
+def test_NLDC_calculation_wind_set():  # noqa: N802
     assert calculate_NLDC(scenario, {"wind"}, 10) == approx(3496.1)
 
 
-def test_NLDC_calculation_wind_tuple():
+def test_NLDC_calculation_wind_tuple():  # noqa: N802
     assert calculate_NLDC(scenario, ("wind",), 10) == approx(3496.1)
 
 
-def test_NLDC_calculation_wind_list():
+def test_NLDC_calculation_wind_list():  # noqa: N802
     assert calculate_NLDC(scenario, ["wind"], 10) == approx(3496.1)
 
 
-def test_NLDC_calculation_wind_5_hour():
+def test_NLDC_calculation_wind_5_hour():  # noqa: N802
     assert calculate_NLDC(scenario, {"wind"}, hours=5) == approx(3343)
 
 
-def test_NLDC_calculation_solar():
+def test_NLDC_calculation_solar():  # noqa: N802
     assert calculate_NLDC(scenario, {"solar"}, 10) == approx(3720)
 
 
-def test_NLDC_calculation_wind_solar():
+def test_NLDC_calculation_wind_solar():  # noqa: N802
     assert calculate_NLDC(scenario, ["wind", "solar"], 10) == approx(8478.9)
 
 
-def test_NLDC_calculation_solar_wind():
+def test_NLDC_calculation_solar_wind():  # noqa: N802
     assert calculate_NLDC(scenario, ["solar", "wind"], 10) == approx(8478.9)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     {format,checkformatting}: black
     {format,checkformatting}: isort
     flake8: flake8
+    flake8: pep8-naming
 commands =
     pytest: pipenv sync --dev
     pytest: pytest


### PR DESCRIPTION
### Purpose
Continuation of https://github.com/Breakthrough-Energy/RenewableEnergyProject/issues/343

### What the code is doing
Adds the check to default `tox` invocation, as part of the `flake8` "testenv".

### Testing
`tox -e flake8`

### Time estimate
3 min
