### PR TITLE
ci: build and push docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,25 @@
+name: Publish docker image
+
+on:
+  push:
+    branches:
+      - 'develop'
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            ghcr.io/breakthrough-energy/postreise:latest


### PR DESCRIPTION
### Purpose
Copy pasted from Breakthrough-Energy/PowerSimData#431 
Original issue: Breakthrough-Energy/plug#10. 

This image will be used in [plug](https://github.com/Breakthrough-Energy/plug) as main point of user interaction, since it contains both powersimdata and postreise. 

### Testing
Ran the workflow on this branch and checked the image was successfully pushed.

### Time estimate
3 min
