### PR TITLE
fix: install ipywidgets for tqdm progress bar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/breakthrough-energy/powersimdata:latest
 WORKDIR /PostRIESE
 COPY Pipfile .
 COPY Pipfile.lock .
-RUN pip install -U pip pipenv jupyterlab; \
+RUN pip install -U pip pipenv jupyterlab ipywidgets; \
     pipenv sync --dev --system;
 
 COPY . .


### PR DESCRIPTION
### Purpose
Fix progress bar error when running notebook in container

### What the code is doing
Install [ipywidgets](https://ipywidgets.readthedocs.io/en/stable/user_install.html) to fix this [error](https://stackoverflow.com/questions/53247985/tqdm-4-28-1-in-jupyter-notebook-intprogress-not-found-please-update-jupyter-an)

### Testing
I ran `!pip install ipywidgets` in the notebook and got a progress bar

### Time estimate
30 sec
