### PR TITLE
feat: improve flexibility of utilization, risk, and bind maps

### DIFF
--- a/postreise/plot/colors.py
+++ b/postreise/plot/colors.py
@@ -16,3 +16,18 @@ shadow_price_pallette = [
     "#d73027",
     "#8b0000",
 ]
+
+traffic_palette = [
+    "darkgreen",
+    "green",
+    "limegreen",
+    "lawngreen",
+    "yellowgreen",
+    "yellow",
+    "gold",
+    "goldenrod",
+    "orange",
+    "orangered",
+    "red",
+    "darkred",
+]

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -27,6 +27,7 @@ def map_risk_bind(
     select_branch_scale_factor=1e-3,
     select_branch_min_width=2,
     figsize=(1400, 800),
+    show_color_bar=True,
 ):
     """Makes map showing risk or binding incidents on US states map.
 
@@ -47,6 +48,7 @@ def map_risk_bind(
     :param int/float select_branch_scale_factor: scale factor for highlighted branches.
     :param int/float select_branch_min_width: minimum width for highlighted branches.
     :param tuple(int, int) figsize: size of the bokeh figure (in pixels).
+    :param bool show_color_bar: whether to render the color bar on the figure.
     :return: (*bokeh.plotting.figure*) -- map of lines with risk and bind incidents
         color coded.
     """
@@ -88,15 +90,6 @@ def map_risk_bind(
     mapper = linear_cmap(
         field_name=risk_or_bind, palette=palette, low=min_val, high=max_val
     )
-    color_bar = ColorBar(
-        color_mapper=mapper["transform"],
-        width=385 if is_website else 500,
-        height=5,
-        location=(0, 0),
-        title=risk_or_bind_units,
-        orientation="horizontal",
-        padding=5,
-    )
     multi_line_source = ColumnDataSource(
         {
             "xs": branch_map[["from_x", "to_x"]].values.tolist(),
@@ -121,7 +114,17 @@ def map_risk_bind(
         output_backend="webgl",
         match_aspect=True,
     )
-    p.add_layout(color_bar, "center")
+    if show_color_bar:
+        color_bar = ColorBar(
+            color_mapper=mapper["transform"],
+            width=385 if is_website else 500,
+            height=5,
+            location=(0, 0),
+            title=risk_or_bind_units,
+            orientation="horizontal",
+            padding=5,
+        )
+        p.add_layout(color_bar, "center")
     p.add_tile(get_provider(Vendors.CARTODBPOSITRON))
     p.patches(a, b, fill_alpha=0.0, line_color="gray", line_width=1)
     p.multi_line(

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -207,11 +207,8 @@ def map_utilization(
         }
     )
 
-    # Set up figure
-    tools: str = "pan,wheel_zoom,reset,save"
-
     p = figure(
-        tools=tools,
+        tools="pan,wheel_zoom,reset,save",
         x_axis_location=None,
         y_axis_location=None,
         plot_width=800,

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -21,6 +21,7 @@ def map_risk_bind(
     vmin=None,
     vmax=None,
     is_website=False,
+    palette=None,
 ):
     """Makes map showing risk or binding incidents on US states map.
 
@@ -33,6 +34,9 @@ def map_risk_bind(
     :param int/float vmin: minimum value for color range. If None, use data minimum.
     :param int/float vmax: maximum value for color range. If None, use data maximum.
     :param bool is_website: changes text/legend formatting to look better on the website
+    :param iterable palette: sequence of colors used for color range, passed as
+        `palette` kwarg to :func:`bokeh.transform.linear_cmap`.
+        If None, default to `postreise.plot.colors.traffic_palette`.
     :return:  -- map of lines with risk and bind incidents color coded
     """
     if us_states_dat is None:
@@ -43,6 +47,9 @@ def map_risk_bind(
 
     if risk_or_bind == "bind":
         risk_or_bind_units = "Binding incidents"
+
+    if palette is None:
+        palette = list(traffic_palette)
 
     # projection steps for mapping
     branch_congestion = pd.concat(
@@ -65,7 +72,7 @@ def map_risk_bind(
     min_val = branch_congestion[risk_or_bind].min() if vmin is None else vmin
     max_val = branch_congestion[risk_or_bind].max() if vmax is None else vmax
     mapper = linear_cmap(
-        field_name=risk_or_bind, palette=traffic_palette, low=min_val, high=max_val
+        field_name=risk_or_bind, palette=palette, low=min_val, high=max_val
     )
     color_bar = ColorBar(
         color_mapper=mapper["transform"],

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -60,6 +60,8 @@ def map_risk_bind(
     :param bool show_color_bar: whether to render the color bar on the figure.
     :param dict plot_states_kwargs: keyword arguments to be passed to
         :func:`postreise.plot.plot_states.plot_states`.
+    :raises ValueError: if (``scenario`` XOR (``congestion_stats`` AND ``branch``)) are
+        not properly specified.
     :return: (*bokeh.plotting.figure*) -- map of lines with risk and bind incidents
         color coded.
     """
@@ -196,6 +198,8 @@ def map_utilization(
     :param tuple(int, int) figsize: size of the bokeh figure (in pixels).
     :param dict plot_states_kwargs: keyword arguments to be passed to
         :func:`postreise.plot.plot_states.plot_states`.
+    :raises ValueError: if (``scenario`` XOR (``utilization_df`` AND ``branch``)) are
+        not properly specified.
     :return: (*bokeh.plotting.figure*) -- map of lines with median utilization color
         coded.
     """

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -97,6 +97,7 @@ def map_risk_bind(
         plot_width=figsize[0],
         plot_height=figsize[1],
         output_backend="webgl",
+        sizing_mode="scale_both",
         match_aspect=True,
     )
     if show_color_bar:
@@ -214,6 +215,7 @@ def map_utilization(
         plot_width=figsize[0],
         plot_height=figsize[1],
         output_backend="webgl",
+        sizing_mode="scale_both",
         match_aspect=True,
     )
     if show_color_bar:

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -66,16 +66,6 @@ def map_risk_bind(
         [branch.loc[congestion_stats.index], congestion_stats], axis=1
     )
     branch_map_all = project_branch(branch)
-    multi_line_source_all = ColumnDataSource(
-        {
-            "xs": branch_map_all[["from_x", "to_x"]].values.tolist(),
-            "ys": branch_map_all[["from_y", "to_y"]].values.tolist(),
-            "cap": (
-                branch_map_all["rateA"] * all_branch_scale_factor
-                + all_branch_min_width
-            ),
-        }
-    )
     tools: str = "pan,wheel_zoom,reset,save"
 
     branch_congestion = branch_congestion[branch_congestion[risk_or_bind] > 0]
@@ -128,11 +118,12 @@ def map_risk_bind(
         all_plot_states_kwargs = default_plot_states_kwargs
     plot_states(bokeh_figure=p, **all_plot_states_kwargs)
     p.multi_line(
-        "xs",
-        "ys",
+        branch_map_all[["from_x", "to_x"]].to_numpy().tolist(),
+        branch_map_all[["from_y", "to_y"]].to_numpy().tolist(),
         color="gray",
-        line_width="cap",
-        source=multi_line_source_all,
+        line_width=(
+            branch_map_all["rateA"] * all_branch_scale_factor + all_branch_min_width
+        ),
         alpha=0.5,
     )
     lines = p.multi_line(

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -184,7 +184,7 @@ def map_utilization(
     min_val = lines["median_utilization"].min() if vmin is None else vmin
     max_val = lines["median_utilization"].max() if vmax is None else vmax
 
-    mapper1 = linear_cmap(
+    mapper = linear_cmap(
         field_name="median_utilization",
         palette=palette,
         low=min_val,
@@ -192,7 +192,7 @@ def map_utilization(
     )
 
     color_bar = ColorBar(
-        color_mapper=mapper1["transform"],
+        color_mapper=mapper["transform"],
         width=385 if is_website else 500,
         height=5,
         location=(0, 0),
@@ -233,7 +233,7 @@ def map_utilization(
         all_plot_states_kwargs = default_plot_states_kwargs
     plot_states(bokeh_figure=p, **all_plot_states_kwargs)
     lines = p.multi_line(
-        "xs", "ys", color=mapper1, line_width="width", source=multi_line_source
+        "xs", "ys", color=mapper, line_width="width", source=multi_line_source
     )
     hover = HoverTool(
         tooltips=[

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -47,7 +47,8 @@ def map_risk_bind(
     :param int/float select_branch_scale_factor: scale factor for highlighted branches.
     :param int/float select_branch_min_width: minimum width for highlighted branches.
     :param tuple(int, int) figsize: size of the bokeh figure (in pixels).
-    :return:  -- map of lines with risk and bind incidents color coded
+    :return: (*bokeh.plotting.figure*) -- map of lines with risk and bind incidents
+        color coded.
     """
     if us_states_dat is None:
         us_states_dat = get_state_borders()

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -145,6 +145,7 @@ def map_utilization(
     vmin=None,
     vmax=None,
     is_website=False,
+    palette=None,
     branch_scale_factor=5e-4,
     branch_min_width=0.2,
     figsize=(1400, 800),
@@ -159,6 +160,9 @@ def map_utilization(
     :param int/float vmin: minimum value for color range. If None, use data minimum.
     :param int/float vmax: maximum value for color range. If None, use data maximum.
     :param bool is_website: changes text/legend formatting to look better on the website
+    :param iterable palette: sequence of colors used for color range, passed as
+        `palette` kwarg to :func:`bokeh.transform.linear_cmap`.
+        If None, default to `postreise.plot.colors.traffic_palette`.
     :param int/float branch_scale_factor: scale factor for branches.
     :param int/float branch_min_width: minimum width for branches.
     :param tuple(int, int) figsize: size of the bokeh figure (in pixels).
@@ -167,6 +171,9 @@ def map_utilization(
     :return: (*bokeh.plotting.figure*) -- map of lines with median utilization color
         coded.
     """
+    if palette is None:
+        palette = list(traffic_palette)
+
     branch_mask = branch.rateA != 0
     median_util = utilization_df[branch.loc[branch_mask].index].median()
     branch_utilization = pd.concat(
@@ -179,7 +186,7 @@ def map_utilization(
 
     mapper1 = linear_cmap(
         field_name="median_utilization",
-        palette=traffic_palette,
+        palette=palette,
         low=min_val,
         high=max_val,
     )

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -8,23 +8,9 @@ from bokeh.plotting import figure
 from bokeh.tile_providers import Vendors, get_provider
 from bokeh.transform import linear_cmap
 
+from postreise.plot.colors import traffic_palette
 from postreise.plot.plot_states import get_state_borders
 from postreise.plot.projection_helpers import project_borders, project_branch
-
-traffic_palette = [
-    "darkgreen",
-    "green",
-    "limegreen",
-    "lawngreen",
-    "yellowgreen",
-    "yellow",
-    "gold",
-    "goldenrod",
-    "orange",
-    "orangered",
-    "red",
-    "darkred",
-]
 
 
 def map_risk_bind(

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -24,7 +24,7 @@ def map_risk_bind(
     us_states_dat=None,
     vmin=None,
     vmax=None,
-    is_website=False,
+    color_bar_width=500,
     palette=None,
     all_branch_scale_factor=0.5,
     all_branch_min_width=0.2,
@@ -44,7 +44,7 @@ def map_risk_bind(
     :param pandas.DataFrame branch: branch data frame.
     :param int/float vmin: minimum value for color range. If None, use data minimum.
     :param int/float vmax: maximum value for color range. If None, use data maximum.
-    :param bool is_website: changes text/legend formatting to look better on the website
+    :param int color_bar_width: width of color bar (pixels).
     :param iterable palette: sequence of colors used for color range, passed as
         `palette` kwarg to :func:`bokeh.transform.linear_cmap`.
         If None, default to `postreise.plot.colors.traffic_palette`.
@@ -127,7 +127,7 @@ def map_risk_bind(
     if show_color_bar:
         color_bar = ColorBar(
             color_mapper=mapper["transform"],
-            width=385 if is_website else 500,
+            width=color_bar_width,
             height=5,
             location=(0, 0),
             title=risk_or_bind_units,
@@ -171,7 +171,7 @@ def map_utilization(
     branch=None,
     vmin=None,
     vmax=None,
-    is_website=False,
+    color_bar_width=500,
     palette=None,
     branch_scale_factor=0.5,
     branch_min_width=0.2,
@@ -189,7 +189,7 @@ def map_utilization(
     :param pandas.DataFrame branch: branch data frame.
     :param int/float vmin: minimum value for color range. If None, use data minimum.
     :param int/float vmax: maximum value for color range. If None, use data maximum.
-    :param bool is_website: changes text/legend formatting to look better on the website
+    :param int color_bar_width: width of color bar (pixels).
     :param iterable palette: sequence of colors used for color range, passed as
         `palette` kwarg to :func:`bokeh.transform.linear_cmap`.
         If None, default to `postreise.plot.colors.traffic_palette`.
@@ -263,7 +263,7 @@ def map_utilization(
     if show_color_bar:
         color_bar = ColorBar(
             color_mapper=mapper["transform"],
-            width=385 if is_website else 500,
+            width=color_bar_width,
             height=5,
             location=(0, 0),
             title="median utilization",

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -146,6 +146,8 @@ def map_utilization(
     vmin=None,
     vmax=None,
     is_website=False,
+    branch_scale_factor=5e-4,
+    branch_min_width=0.2,
     plot_states_kwargs=None,
 ):
     """Makes map showing utilization. Utilization input can either be medians
@@ -157,6 +159,8 @@ def map_utilization(
     :param int/float vmin: minimum value for color range. If None, use data minimum.
     :param int/float vmax: maximum value for color range. If None, use data maximum.
     :param bool is_website: changes text/legend formatting to look better on the website
+    :param int/float branch_scale_factor: scale factor for branches.
+    :param int/float branch_min_width: minimum width for branches.
     :param dict plot_states_kwargs: keyword arguments to be passed to
         :func:`postreise.plot.plot_states.plot_states`.
     :return: (*bokeh.plotting.figure*) -- map of lines with median utilization color
@@ -198,7 +202,7 @@ def map_utilization(
             "xs": branch_map[["from_x", "to_x"]].values.tolist(),
             "ys": branch_map[["from_y", "to_y"]].values.tolist(),
             "median_utilization": branch_map.median_utilization,
-            "cap": branch_map.rateA / 2000 + 0.2,
+            "width": branch_map.rateA * branch_scale_factor + branch_min_width,
             "util": branch_map.median_utilization.round(2),
             "capacity": branch_map.rateA.round(),
         }
@@ -225,7 +229,7 @@ def map_utilization(
         all_plot_states_kwargs = default_plot_states_kwargs
     plot_states(bokeh_figure=p, **all_plot_states_kwargs)
     lines = p.multi_line(
-        "xs", "ys", color=mapper1, line_width="cap", source=multi_line_source
+        "xs", "ys", color=mapper1, line_width="width", source=multi_line_source
     )
     hover = HoverTool(
         tooltips=[

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -26,6 +26,7 @@ def map_risk_bind(
     all_branch_min_width=0.2,
     select_branch_scale_factor=1e-3,
     select_branch_min_width=2,
+    figsize=(1400, 800),
 ):
     """Makes map showing risk or binding incidents on US states map.
 
@@ -45,6 +46,7 @@ def map_risk_bind(
     :param int/float all_branch_min_width: minimum width for unhighlighted branches.
     :param int/float select_branch_scale_factor: scale factor for highlighted branches.
     :param int/float select_branch_min_width: minimum width for highlighted branches.
+    :param tuple(int, int) figsize: size of the bokeh figure (in pixels).
     :return:  -- map of lines with risk and bind incidents color coded
     """
     if us_states_dat is None:
@@ -113,10 +115,9 @@ def map_risk_bind(
         tools=tools,
         x_axis_location=None,
         y_axis_location=None,
-        plot_width=800,
-        plot_height=800,
+        plot_width=figsize[0],
+        plot_height=figsize[1],
         output_backend="webgl",
-        sizing_mode="stretch_both",
         match_aspect=True,
     )
     p.add_layout(color_bar, "center")

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -66,7 +66,6 @@ def map_risk_bind(
         [branch.loc[congestion_stats.index], congestion_stats], axis=1
     )
     branch_map_all = project_branch(branch)
-    tools: str = "pan,wheel_zoom,reset,save"
 
     branch_congestion = branch_congestion[branch_congestion[risk_or_bind] > 0]
     branch_congestion.sort_values(by=[risk_or_bind])
@@ -92,7 +91,7 @@ def map_risk_bind(
 
     # Set up figure
     p = figure(
-        tools=tools,
+        tools="pan,wheel_zoom,reset,save",
         x_axis_location=None,
         y_axis_location=None,
         plot_width=figsize[0],

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -149,6 +149,7 @@ def map_utilization(
     branch_scale_factor=5e-4,
     branch_min_width=0.2,
     figsize=(1400, 800),
+    show_color_bar=True,
     plot_states_kwargs=None,
 ):
     """Makes map showing utilization. Utilization input can either be medians
@@ -191,16 +192,6 @@ def map_utilization(
         high=max_val,
     )
 
-    color_bar = ColorBar(
-        color_mapper=mapper["transform"],
-        width=385 if is_website else 500,
-        height=5,
-        location=(0, 0),
-        title="median utilization",
-        orientation="horizontal",
-        padding=5,
-    )
-
     branch_map = project_branch(branch_utilization)
     branch_map = branch_map.sort_values(by=["median_utilization"])
     branch_map = branch_map[~branch_map.isin([np.nan, np.inf, -np.inf]).any(1)]
@@ -225,7 +216,17 @@ def map_utilization(
         output_backend="webgl",
         match_aspect=True,
     )
-    p.add_layout(color_bar, "center")
+    if show_color_bar:
+        color_bar = ColorBar(
+            color_mapper=mapper["transform"],
+            width=385 if is_website else 500,
+            height=5,
+            location=(0, 0),
+            title="median utilization",
+            orientation="horizontal",
+            padding=5,
+        )
+        p.add_layout(color_bar, "center")
     default_plot_states_kwargs = {"fill_alpha": 0.0, "line_width": 2}
     if plot_states_kwargs is not None:
         all_plot_states_kwargs = default_plot_states_kwargs.update(**plot_states_kwargs)

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -22,6 +22,10 @@ def map_risk_bind(
     vmax=None,
     is_website=False,
     palette=None,
+    all_branch_scale_factor=5e-4,
+    all_branch_min_width=0.2,
+    select_branch_scale_factor=1e-3,
+    select_branch_min_width=2,
 ):
     """Makes map showing risk or binding incidents on US states map.
 
@@ -37,6 +41,10 @@ def map_risk_bind(
     :param iterable palette: sequence of colors used for color range, passed as
         `palette` kwarg to :func:`bokeh.transform.linear_cmap`.
         If None, default to `postreise.plot.colors.traffic_palette`.
+    :param int/float all_branch_scale_factor: scale factor for unhighlighted branches.
+    :param int/float all_branch_min_width: minimum width for unhighlighted branches.
+    :param int/float select_branch_scale_factor: scale factor for highlighted branches.
+    :param int/float select_branch_min_width: minimum width for highlighted branches.
     :return:  -- map of lines with risk and bind incidents color coded
     """
     if us_states_dat is None:
@@ -60,7 +68,10 @@ def map_risk_bind(
         {
             "xs": branch_map_all[["from_x", "to_x"]].values.tolist(),
             "ys": branch_map_all[["from_y", "to_y"]].values.tolist(),
-            "cap": branch_map_all["rateA"] / 2000 + 0.2,
+            "cap": (
+                branch_map_all["rateA"] * all_branch_scale_factor
+                + all_branch_min_width
+            ),
         }
     )
     a, b = project_borders(us_states_dat)
@@ -89,7 +100,10 @@ def map_risk_bind(
             "ys": branch_map[["from_y", "to_y"]].values.tolist(),
             risk_or_bind: branch_map[risk_or_bind],
             "value": branch_map[risk_or_bind].round(),
-            "cap": branch_map["capacity"] / 1000 + 2,
+            "cap": (
+                branch_map["capacity"] * select_branch_scale_factor
+                + select_branch_min_width
+            ),
             "capacity": branch_map.rateA.round(),
         }
     )

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -147,6 +147,7 @@ def map_utilization(
     is_website=False,
     branch_scale_factor=5e-4,
     branch_min_width=0.2,
+    figsize=(1400, 800),
     plot_states_kwargs=None,
 ):
     """Makes map showing utilization. Utilization input can either be medians
@@ -160,6 +161,7 @@ def map_utilization(
     :param bool is_website: changes text/legend formatting to look better on the website
     :param int/float branch_scale_factor: scale factor for branches.
     :param int/float branch_min_width: minimum width for branches.
+    :param tuple(int, int) figsize: size of the bokeh figure (in pixels).
     :param dict plot_states_kwargs: keyword arguments to be passed to
         :func:`postreise.plot.plot_states.plot_states`.
     :return: (*bokeh.plotting.figure*) -- map of lines with median utilization color
@@ -211,10 +213,9 @@ def map_utilization(
         tools="pan,wheel_zoom,reset,save",
         x_axis_location=None,
         y_axis_location=None,
-        plot_width=800,
-        plot_height=800,
+        plot_width=figsize[0],
+        plot_height=figsize[1],
         output_backend="webgl",
-        sizing_mode="stretch_both",
         match_aspect=True,
     )
     p.add_layout(color_bar, "center")

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -21,9 +21,9 @@ def map_risk_bind(
     vmax=None,
     is_website=False,
     palette=None,
-    all_branch_scale_factor=5e-4,
+    all_branch_scale_factor=0.5,
     all_branch_min_width=0.2,
-    select_branch_scale_factor=1e-3,
+    select_branch_scale_factor=1,
     select_branch_min_width=2,
     figsize=(1400, 800),
     show_color_bar=True,
@@ -41,10 +41,14 @@ def map_risk_bind(
     :param iterable palette: sequence of colors used for color range, passed as
         `palette` kwarg to :func:`bokeh.transform.linear_cmap`.
         If None, default to `postreise.plot.colors.traffic_palette`.
-    :param int/float all_branch_scale_factor: scale factor for unhighlighted branches.
-    :param int/float all_branch_min_width: minimum width for unhighlighted branches.
-    :param int/float select_branch_scale_factor: scale factor for highlighted branches.
-    :param int/float select_branch_min_width: minimum width for highlighted branches.
+    :param int/float all_branch_scale_factor: scale factor for unhighlighted branches
+        (pixels/GW).
+    :param int/float all_branch_min_width: minimum width for unhighlighted branches
+        (pixels).
+    :param int/float select_branch_scale_factor: scale factor for highlighted branches
+        (pixels/GW).
+    :param int/float select_branch_min_width: minimum width for highlighted branches
+        (pixels).
     :param tuple(int, int) figsize: size of the bokeh figure (in pixels).
     :param bool show_color_bar: whether to render the color bar on the figure.
     :param dict plot_states_kwargs: keyword arguments to be passed to
@@ -82,7 +86,7 @@ def map_risk_bind(
             risk_or_bind: branch_map[risk_or_bind],
             "value": branch_map[risk_or_bind].round(),
             "cap": (
-                branch_map["capacity"] * select_branch_scale_factor
+                branch_map["capacity"] * select_branch_scale_factor / 1000
                 + select_branch_min_width
             ),
             "capacity": branch_map.rateA.round(),
@@ -122,7 +126,8 @@ def map_risk_bind(
         branch_map_all[["from_y", "to_y"]].to_numpy().tolist(),
         color="gray",
         line_width=(
-            branch_map_all["rateA"] * all_branch_scale_factor + all_branch_min_width
+            branch_map_all["rateA"] * all_branch_scale_factor / 1000
+            + all_branch_min_width
         ),
         alpha=0.5,
     )
@@ -147,7 +152,7 @@ def map_utilization(
     vmax=None,
     is_website=False,
     palette=None,
-    branch_scale_factor=5e-4,
+    branch_scale_factor=0.5,
     branch_min_width=0.2,
     figsize=(1400, 800),
     show_color_bar=True,
@@ -165,8 +170,8 @@ def map_utilization(
     :param iterable palette: sequence of colors used for color range, passed as
         `palette` kwarg to :func:`bokeh.transform.linear_cmap`.
         If None, default to `postreise.plot.colors.traffic_palette`.
-    :param int/float branch_scale_factor: scale factor for branches.
-    :param int/float branch_min_width: minimum width for branches.
+    :param int/float branch_scale_factor: scale factor for branches (pixels/GW).
+    :param int/float branch_min_width: minimum width for branches (pixels).
     :param tuple(int, int) figsize: size of the bokeh figure (in pixels).
     :param dict plot_states_kwargs: keyword arguments to be passed to
         :func:`postreise.plot.plot_states.plot_states`.
@@ -202,7 +207,7 @@ def map_utilization(
             "xs": branch_map[["from_x", "to_x"]].values.tolist(),
             "ys": branch_map[["from_y", "to_y"]].values.tolist(),
             "median_utilization": branch_map.median_utilization,
-            "width": branch_map.rateA * branch_scale_factor + branch_min_width,
+            "width": branch_map.rateA * branch_scale_factor / 1000 + branch_min_width,
             "util": branch_map.median_utilization.round(2),
             "capacity": branch_map.rateA.round(),
         }

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -159,7 +159,8 @@ def map_utilization(
     :param bool is_website: changes text/legend formatting to look better on the website
     :param dict plot_states_kwargs: keyword arguments to be passed to
         :func:`postreise.plot.plot_states.plot_states`.
-    :return:  -- map of lines with median utilization color coded
+    :return: (*bokeh.plotting.figure*) -- map of lines with median utilization color
+        coded.
     """
     branch_mask = branch.rateA != 0
     median_util = utilization_df[branch.loc[branch_mask].index].median()

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -56,11 +56,10 @@ def map_risk_bind(
     :return: (*bokeh.plotting.figure*) -- map of lines with risk and bind incidents
         color coded.
     """
-    if risk_or_bind == "risk":
-        risk_or_bind_units = "Risk (MWH)"
-
-    if risk_or_bind == "bind":
-        risk_or_bind_units = "Binding incidents"
+    unit_labels = {"risk": "Risk (MWH)", "bind": "Binding incidents"}
+    if risk_or_bind not in unit_labels:
+        raise ValueError("risk_or_bind must be either 'risk' or 'bind'")
+    risk_or_bind_units = unit_labels[risk_or_bind]
 
     if palette is None:
         palette = list(traffic_palette)


### PR DESCRIPTION
### Purpose
A couple of times now, we have needed to produce maps of all congested branches, with a custom color palette, and custom line thickness settings. This was achieved in a quick-and-dirty way by directly editing the hard-coded values in a local copy of PostREISE; this PR integrates these options into the plotting functions.

### What the code is doing
- We move the `traffic_palette` into **colors.py**
- We allow the user to supply a custom color palette.
- We change the hard-coded values for determining branch thickness into something user-configurable, with default values.
- We allow the user to specify the figure dimensions.
- We allow the user to specify whether the color bar is displayed or not.
- We make use of the built-in `plot_states` function, and allow the user to pass keyword arguments to this function to control e.g. whether or not to plot the background, line colors and thicknesses, etc.
- We remove one `ColumnLineSource`, which is not needed if all we need is to call `multi_line`. Other column data sources are preserved for the sake of maintaining hover functionality.

### Testing
I used the demo notebook to test the before/after of the refactor. Besides changing the figure size (previously it would expand to fill your browser window), the figures with the default values appear identical.

Before:
![util_v0](https://user-images.githubusercontent.com/7348392/115327606-15c4d000-a144-11eb-94a1-786c62d8eeae.png)

After:
![util_v1](https://user-images.githubusercontent.com/7348392/115327622-1b221a80-a144-11eb-9b7d-80a78dc498db.png)

Before:
![risk_v0](https://user-images.githubusercontent.com/7348392/115327630-1f4e3800-a144-11eb-9231-220453d9279f.png)

After:
![risk_v1](https://user-images.githubusercontent.com/7348392/115327638-237a5580-a144-11eb-90ba-027bc9cb60ad.png)

### Usage Example/Visuals
We can also use the new functionality for customization:
```python
plot_utilization_map.map_risk_bind(
    "bind", cong_stats_example, branch, vmin=0, vmax=1, show_color_bar=False, palette=["red"]
)
```
![bind_v1](https://user-images.githubusercontent.com/7348392/115327699-3c830680-a144-11eb-98a4-fc82ee073f26.png)


### Time estimate
15 minutes. This is a relatively low priority, but something that I wanted to at least start a PR for rather than letting it sit in my local repo forever.
