### PR TITLE
refactor: move cost calculation function to separate module

### DIFF
--- a/postreise/analyze/generation/costs.py
+++ b/postreise/analyze/generation/costs.py
@@ -1,0 +1,57 @@
+import numpy as np
+import pandas as pd
+from numpy.polynomial.polynomial import polyval
+
+from postreise.analyze.check import (
+    _check_gencost,
+    _check_scenario_is_in_analyze_state,
+    _check_time_series,
+)
+
+
+def calculate_costs(
+    scenario=None, pg=None, gencost=None, decommit=False, decommit_threshold=1
+):
+    """Calculate individual generator costs at given powers. If decommit is
+    True, costs will be zero below the decommit threshold (1 MW).
+    Either ``scenario`` XOR (``pg`` AND ``gencost``) must be specified.
+
+    :param powersimdata.scenario.scenario.Scenario scenario: scenario to analyze.
+    :param pandas.DataFrame pg: Generation solution data frame.
+    :param pandas.DataFrame gencost: cost curve polynomials.
+    :param bool decommit: Whether to decommit generator at low power.
+    :param int/float decommit_threshold: The power (MW) below which generators are
+        assumed to be 'decommitted', and costs are zero (if ``decommit`` is True).
+    :raises ValueError: if not (``scenario`` XOR (``pg`` AND ``gencost``)) is specified,
+        or if ``pg`` is passed and has negative values.
+    :return: (*pandas.DataFrame*) -- data frame of costs.
+        Index is hours, columns are plant IDs, values are $/hour.
+    """
+
+    # Check that we've appropriately specified `scenario` XOR (`pg` AND `gencost`)
+    if not ((scenario is not None) ^ (pg is not None and gencost is not None)):
+        raise ValueError("Either scenario XOR (pg AND gencost) must be specified")
+    if scenario is not None:
+        _check_scenario_is_in_analyze_state(scenario)
+        pg = scenario.state.get_pg()
+        gencost = scenario.state.get_grid().gencost["before"]
+    else:
+        _check_gencost(gencost)
+        _check_time_series(pg, "PG")
+        if (pg < -1e-3).any(axis=None):
+            raise ValueError("PG must be non-negative")
+    # get ordered polynomial coefficients in columns, discarding non-coefficient data
+    num_coefficients = gencost["n"].iloc[0]
+    coefficient_columns = [f"c{i}" for i in range(num_coefficients)]
+    coefficients = gencost[coefficient_columns].to_numpy().T
+
+    # elementwise, evaluate polynomial where x = value
+    costs = polyval(pg.to_numpy(), coefficients, tensor=False)
+
+    if decommit:
+        # mask values where pg is 0 to 0 cost (assume uncommitted, no cost)
+        costs = np.where(pg.to_numpy() < decommit_threshold, 0, costs)
+
+    # Finally, convert to dataframe with shape that matches `pg`
+    costs = pd.DataFrame(costs, columns=pg.columns, index=pg.index)
+    return costs

--- a/postreise/analyze/generation/tests/test_costs.py
+++ b/postreise/analyze/generation/tests/test_costs.py
@@ -1,0 +1,80 @@
+import pandas as pd
+import pytest
+from powersimdata.tests.mock_scenario import MockScenario
+
+from postreise.analyze.generation.costs import calculate_costs
+
+
+@pytest.fixture
+def mock_gencost_data():
+    # plant_id is the index
+    return {
+        "plant_id": [101, 102, 103, 104, 105],
+        "type": [2] * 5,
+        "startup": [0] * 5,
+        "shutdown": [0] * 5,
+        "n": [3] * 5,
+        "c2": [1, 2, 3, 4, 5],
+        "c1": [10, 20, 30, 40, 50],
+        "c0": [100, 200, 300, 400, 500],
+        "interconnect": ["Western"] * 5,
+    }
+
+
+@pytest.fixture
+def mock_gencost(mock_gencost_data):
+    # Reproducing manually what would be done inside MockGrid
+    return pd.DataFrame(mock_gencost_data).set_index("plant_id")
+
+
+@pytest.fixture
+def mock_plant():
+    # plant_id is the index
+    return {
+        "plant_id": [101, 102, 103, 104, 105],
+        "bus_id": [1001, 1002, 1003, 1004, 1005],
+        "type": ["solar", "wind", "ng", "coal", "dfo"],
+        "GenFuelCost": [0, 0, 3.3, 4.4, 5.5],
+    }
+
+
+@pytest.fixture
+def mock_pg(mock_plant):
+    return pd.DataFrame(
+        {
+            plant_id: [(i + 1) * p for p in range(4)]
+            for i, plant_id in enumerate(mock_plant["plant_id"])
+        },
+        index=pd.date_range("2019-01-01", periods=4, freq="H"),
+    )
+
+
+@pytest.fixture
+def mock_scenario(mock_gencost_data, mock_pg):
+    return MockScenario(grid_attrs={"gencost_before": mock_gencost_data}, pg=mock_pg)
+
+
+def test_calculate_cost_equal_both_methods(mock_gencost, mock_pg, mock_scenario):
+    scenario_calculated = calculate_costs(scenario=mock_scenario)
+    gencost_pg_calculated = calculate_costs(gencost=mock_gencost, pg=mock_pg)
+    assert scenario_calculated.equals(gencost_pg_calculated)
+
+
+def test_pass_nothing():
+    with pytest.raises(ValueError):
+        calculate_costs()
+
+
+def test_pass_just_pg(mock_pg):
+    with pytest.raises(ValueError):
+        calculate_costs(pg=mock_pg)
+
+
+def test_pass_just_gencost(mock_gencost):
+    with pytest.raises(ValueError):
+        calculate_costs(gencost=mock_gencost)
+
+
+def test_pass_too_many_things(mock_gencost, mock_pg, mock_scenario):
+    with pytest.raises(ValueError):
+        calculate_costs(gencost=mock_gencost, pg=mock_pg, scenario=mock_scenario)


### PR DESCRIPTION
### Purpose
- Move cost calculation to its own module, since it may be used by people who aren't interested in emissions.
- Improve flexibility of cost calculation code.

### What the code is doing
The logic of cost calculation is not changed. We make it more flexible by taking either a Scenario or `pg` and `gencost` data frames (previous behavior). We correct the output so that it's actually a data frame (previously it was a numpy array, but the docstring said it was a data frame), and we make slight changes to the code in the `emissions` module so that it calls the new function in the right way, and appropriately uses the now-dataframe output.

### Testing
The old method (passing pg and gencost) is still tested via the tests of the `emissions` module. The new method was tested manually.

### Time estimate
5-10 minutes. This is fairly high priority to get into the codebase, since we want to use this in trainings.
