### PR TITLE
chore: add data CSVs to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,6 @@ setup(
     author="Kaspar Mueller",
     author_email="kaspar@breakthroughenergy.org",
     packages=find_packages(),
+    package_data={"postreise": ["data/*.csv"]},
     zip_safe=False,
 )


### PR DESCRIPTION
### Purpose
Copy data CSVs when package is installed via setup.py. This will allow the files to be accessed automatically, no matter how the package is installed, via code like:
```python
import inspect
import os
import postreise
postreise_data = os.path.join(os.path.dirname(inspect.getfile(postreise)), "data")
```

### Time estimate
2 minutes.
