### PR TITLE
refactor: add flexibility to plot_upgrades_map

### DIFF
--- a/postreise/analyze/transmission/upgrades.py
+++ b/postreise/analyze/transmission/upgrades.py
@@ -24,7 +24,7 @@ def get_branch_differences(branch1, branch2):
     :param pandas.DataFrame branch1: data frame containing rateA
     :param pandas.DataFrame branch2: data frame containing rateA
     :return: (*pandas.DataFrame*) -- data frame with all indices and 'diff' column.
-    :raises ValueError: if either dataframe doesn't have required columns.
+    :raises ValueError: if either data frame doesn't have required columns.
     """
     _check_data_frame(branch1, "branch1")
     _check_data_frame(branch2, "branch2")

--- a/postreise/analyze/transmission/upgrades.py
+++ b/postreise/analyze/transmission/upgrades.py
@@ -29,7 +29,7 @@ def get_branch_differences(branch1, branch2):
     _check_data_frame(branch1, "branch1")
     _check_data_frame(branch2, "branch2")
     if not ("rateA" in branch1.columns) and ("rateA" in branch2.columns):
-        raise ValueError("branch1 and branch2 both much have 'rateA' columns")
+        raise ValueError("branch1 and branch2 both must have 'rateA' columns")
     branch1, branch2 = _reindex_as_necessary(branch1, branch2)
     branch_merge = branch1.merge(
         branch2, how="outer", right_index=True, left_index=True, suffixes=(None, "_2")

--- a/postreise/analyze/transmission/upgrades.py
+++ b/postreise/analyze/transmission/upgrades.py
@@ -35,6 +35,12 @@ def get_branch_differences(branch1, branch2):
         branch2, how="outer", right_index=True, left_index=True, suffixes=(None, "_2")
     )
     branch_merge["diff"] = branch_merge.rateA_2.fillna(0) - branch_merge.rateA.fillna(0)
+    # Ensure that lats & lons get filled in as necessary from branch2 entries
+    latlon_columns = ["from_lat", "from_lon", "to_lat", "to_lon"]
+    missing_lat_indices = branch_merge.query("from_lat.isnull()").index
+    branch_merge.loc[missing_lat_indices, latlon_columns] = branch_merge.loc[
+        missing_lat_indices, [f"{l}_2" for l in latlon_columns]
+    ].to_numpy()
     return branch_merge
 
 

--- a/postreise/plot/plot_upgrades_map.py
+++ b/postreise/plot/plot_upgrades_map.py
@@ -54,9 +54,9 @@ def _map_upgrades(
     all_elements_alpha = 0.5
     differences_alpha = 0.8
     # convert scale factors from pixels/GW to pixels/MW (base units for our grid data)
-    all_branch_scale_MW = all_branch_scale / 1000
-    diff_branch_scale_MW = diff_branch_scale / 1000
-    b2b_scale_MW = b2b_scale / 1000
+    all_branch_scale_MW = all_branch_scale / 1000  # noqa: N806
+    diff_branch_scale_MW = diff_branch_scale / 1000  # noqa: N806
+    b2b_scale_MW = b2b_scale / 1000  # noqa: N806
 
     # data prep
     branch_all = project_branch(branch_merge)

--- a/postreise/plot/plot_upgrades_map.py
+++ b/postreise/plot/plot_upgrades_map.py
@@ -53,6 +53,10 @@ def _map_upgrades(
     legend_alpha = 0.9
     all_elements_alpha = 0.5
     differences_alpha = 0.8
+    # convert scale factors from pixels/GW to pixels/MW (base units for our grid data)
+    all_branch_scale_MW = all_branch_scale / 1000
+    diff_branch_scale_MW = diff_branch_scale / 1000
+    b2b_scale_MW = b2b_scale / 1000
 
     # data prep
     branch_all = project_branch(branch_merge)
@@ -85,7 +89,7 @@ def _map_upgrades(
         {
             "xs": branch_all[["from_x", "to_x"]].values.tolist(),
             "ys": branch_all[["from_y", "to_y"]].values.tolist(),
-            "cap": branch_all["rateA"] / 1000 * all_branch_scale + all_branch_min,
+            "cap": branch_all["rateA"] * all_branch_scale_MW + all_branch_min,
             "color": branch_all["color"],
         }
     )
@@ -96,8 +100,7 @@ def _map_upgrades(
             "xs": ac_diff_branches[["from_x", "to_x"]].values.tolist(),
             "ys": ac_diff_branches[["from_y", "to_y"]].values.tolist(),
             "diff": (
-                ac_diff_branches["diff"].abs() / 1000 * diff_branch_scale
-                + diff_branch_min
+                ac_diff_branches["diff"].abs() * diff_branch_scale_MW + diff_branch_min
             ),
             "color": ac_diff_branches["color"],
         }
@@ -106,7 +109,7 @@ def _map_upgrades(
         {
             "xs": branch_dc_lines[["from_x", "to_x"]].values.tolist(),
             "ys": branch_dc_lines[["from_y", "to_y"]].values.tolist(),
-            "cap": branch_dc_lines.Pmax / 1000 * all_branch_scale + all_branch_min,
+            "cap": branch_dc_lines.Pmax * all_branch_scale_MW + all_branch_min,
             "color": branch_dc_lines["color"],
         }
     )
@@ -116,7 +119,7 @@ def _map_upgrades(
             "xs": dc_diff_lines[["from_x", "to_x"]].values.tolist(),
             "ys": dc_diff_lines[["from_y", "to_y"]].values.tolist(),
             "diff": (
-                dc_diff_lines["diff"].abs() / 1000 * diff_branch_scale + diff_branch_min
+                dc_diff_lines["diff"].abs() * diff_branch_scale_MW + diff_branch_min
             ),
             "color": dc_diff_lines["color"],
         }
@@ -125,8 +128,8 @@ def _map_upgrades(
         {
             "xs": b2b[["from_x", "to_x"]].values.tolist(),
             "ys": b2b[["from_y", "to_y"]].values.tolist(),
-            "cap": b2b.Pmax / 1000 * all_branch_scale + all_branch_min,
-            "diff": b2b["diff"].abs() / 1000 * diff_branch_scale + diff_branch_min,
+            "cap": b2b.Pmax * all_branch_scale_MW + all_branch_min,
+            "diff": b2b["diff"].abs() * diff_branch_scale_MW + diff_branch_min,
             "color": b2b["color"],
         }
     )
@@ -237,7 +240,7 @@ def _map_upgrades(
         y=b2b.from_y,
         color="gray",
         marker="triangle",
-        size=b2b["Pmax"].abs() * b2b_scale / 1000,
+        size=b2b["Pmax"].abs() * b2b_scale_MW,
         alpha=all_elements_alpha,
     )
 
@@ -263,7 +266,7 @@ def _map_upgrades(
         y=b2b.from_y,
         color=colors.be_magenta,
         marker="triangle",
-        size=b2b["diff"].abs() * b2b_scale / 1000,
+        size=b2b["diff"].abs() * b2b_scale_MW,
     )
 
     return p

--- a/postreise/plot/plot_upgrades_map.py
+++ b/postreise/plot/plot_upgrades_map.py
@@ -16,8 +16,8 @@ def _map_upgrades(
     dc_merge,
     b2b_indices=None,
     diff_threshold=100,
-    all_branch_scale=1e-3,
-    diff_branch_scale=1e-3,
+    all_branch_scale=1,
+    diff_branch_scale=1,
     all_branch_min=0.1,
     diff_branch_min=1.0,
     b2b_scale=5e-3,
@@ -32,9 +32,10 @@ def _map_upgrades(
     :param iterable b2b_indices: list/set/tuple of 'DC lines' which are back-to-backs.
     :param int/float diff_threshold: difference threshold (in MW), above which branches
         are highlighted.
-    :param int/float all_branch_scale: scale factor for plotting all branches.
+    :param int/float all_branch_scale: scale factor for plotting all branches
+        (pixels/GW).
     :param int/float diff_branch_scale: scale factor for plotting branches with
-        differences above the threshold.
+        differences above the threshold (pixels/GW).
     :param int/float all_branch_min: minimum width to plot all branches.
     :param int/float diff_branch_min: minimum width to plot branches with significant
         differences.
@@ -81,7 +82,7 @@ def _map_upgrades(
         {
             "xs": branch_all[["from_x", "to_x"]].values.tolist(),
             "ys": branch_all[["from_y", "to_y"]].values.tolist(),
-            "cap": branch_all["rateA"] * all_branch_scale + all_branch_min,
+            "cap": branch_all["rateA"] / 1000 * all_branch_scale + all_branch_min,
             "color": branch_all["color"],
         }
     )
@@ -92,7 +93,8 @@ def _map_upgrades(
             "xs": ac_diff_branches[["from_x", "to_x"]].values.tolist(),
             "ys": ac_diff_branches[["from_y", "to_y"]].values.tolist(),
             "diff": (
-                ac_diff_branches["diff"].abs() * diff_branch_scale + diff_branch_min
+                ac_diff_branches["diff"].abs() / 1000 * diff_branch_scale
+                + diff_branch_min
             ),
             "color": ac_diff_branches["color"],
         }
@@ -101,7 +103,7 @@ def _map_upgrades(
         {
             "xs": branch_dc_lines[["from_x", "to_x"]].values.tolist(),
             "ys": branch_dc_lines[["from_y", "to_y"]].values.tolist(),
-            "cap": branch_dc_lines.Pmax * all_branch_scale + all_branch_min,
+            "cap": branch_dc_lines.Pmax / 1000 * all_branch_scale + all_branch_min,
             "color": branch_dc_lines["color"],
         }
     )
@@ -110,7 +112,9 @@ def _map_upgrades(
         {
             "xs": dc_diff_lines[["from_x", "to_x"]].values.tolist(),
             "ys": dc_diff_lines[["from_y", "to_y"]].values.tolist(),
-            "diff": dc_diff_lines["diff"].abs() * diff_branch_scale + diff_branch_min,
+            "diff": (
+                dc_diff_lines["diff"].abs() / 1000 * diff_branch_scale + diff_branch_min
+            ),
             "color": dc_diff_lines["color"],
         }
     )
@@ -118,8 +122,8 @@ def _map_upgrades(
         {
             "xs": b2b[["from_x", "to_x"]].values.tolist(),
             "ys": b2b[["from_y", "to_y"]].values.tolist(),
-            "cap": b2b.Pmax * all_branch_scale + all_branch_min,
-            "diff": b2b["diff"].abs() * diff_branch_scale + diff_branch_min,
+            "cap": b2b.Pmax / 1000 * all_branch_scale + all_branch_min,
+            "diff": b2b["diff"].abs() / 1000 * diff_branch_scale + diff_branch_min,
             "color": b2b["color"],
         }
     )

--- a/postreise/plot/plot_upgrades_map.py
+++ b/postreise/plot/plot_upgrades_map.py
@@ -21,6 +21,8 @@ def _map_upgrades(
     all_branch_min=0.1,
     diff_branch_min=1.0,
     b2b_scale=5e-3,
+    x_range=None,
+    y_range=None,
 ):
     """Makes map of branches showing upgrades
 
@@ -36,6 +38,8 @@ def _map_upgrades(
     :param int/float diff_branch_min: minimum width to plot branches with significant
         differences.
     :param int/float b2b_scale: scale factor for plotting b2b facilities.
+    :param tuple(float, float) x_range: x range to zoom plot to (EPSG:3857).
+    :param tuple(float, float) y_range: y range to zoom plot to (EPSG:3857).
     :return: (*bokeh.plotting.figure.Figure*) -- Bokeh map plot of color-coded upgrades.
     """
     # plotting constants
@@ -127,6 +131,8 @@ def _map_upgrades(
         plot_height=800,
         output_backend="webgl",
         match_aspect=True,
+        x_range=x_range,
+        y_range=y_range,
     )
     p.xgrid.visible = False
     p.ygrid.visible = False

--- a/postreise/plot/plot_upgrades_map.py
+++ b/postreise/plot/plot_upgrades_map.py
@@ -249,21 +249,23 @@ def _map_upgrades(
     return p
 
 
-def map_upgrades(scenario1, scenario2, **plot_kwargs):
+def map_upgrades(scenario1, scenario2, b2b_indices=None, **plot_kwargs):
     """Plot capacity differences for branches & DC lines between two scenarios.
 
     :param powersimdata.scenario.scenario.Scenario scenario1: first scenario.
     :param powersimdata.scenario.scenario.Scenario scenario2: second scenario.
+    :param iterable b2b_indices: list/set/tuple of 'DC lines' which are back-to-backs.
     :param \\*\\*plot_kwargs: collected keyword arguments to be passed to _map_upgrades.
     :return: (*bokeh.plotting.figure.Figure*) -- Bokeh map plot of color-coded upgrades.
     """
-    if not {scenario1.info["interconnect"], scenario2.info["interconnect"]} == {"USA"}:
-        raise ValueError("Scenarios to compare must be USA")
+    if not (
+        scenario1.info["grid_model"] == scenario2.info["grid_model"]
+        and scenario1.info["interconnect"] == scenario2.info["interconnect"]
+    ):
+        raise ValueError("Scenarios to compare must be same grid_model & interconnect")
     grid1 = scenario1.state.get_grid()
     grid2 = scenario2.state.get_grid()
     branch_merge = get_branch_differences(grid1.branch, grid2.branch)
     dc_merge = get_dcline_differences(grid1.dcline, grid2.dcline, grid1.bus)
-    # Since we hardcode to USA only, we know that the first 9 DC Lines are really B2Bs
-    b2b_indices = list(range(9))
     map_plot = _map_upgrades(branch_merge, dc_merge, b2b_indices, **plot_kwargs)
     return map_plot

--- a/postreise/plot/plot_upgrades_map.py
+++ b/postreise/plot/plot_upgrades_map.py
@@ -21,6 +21,7 @@ def _map_upgrades(
     all_branch_min=0.1,
     diff_branch_min=1.0,
     b2b_scale=5e-3,
+    figsize=(1400, 800),
     x_range=None,
     y_range=None,
 ):
@@ -38,6 +39,7 @@ def _map_upgrades(
     :param int/float diff_branch_min: minimum width to plot branches with significant
         differences.
     :param int/float b2b_scale: scale factor for plotting b2b facilities.
+    :param tuple(int, int) figsize: size of the bokeh figure (in pixels).
     :param tuple(float, float) x_range: x range to zoom plot to (EPSG:3857).
     :param tuple(float, float) y_range: y range to zoom plot to (EPSG:3857).
     :return: (*bokeh.plotting.figure.Figure*) -- Bokeh map plot of color-coded upgrades.
@@ -127,8 +129,8 @@ def _map_upgrades(
         tools=bokeh_tools,
         x_axis_location=None,
         y_axis_location=None,
-        plot_width=1400,
-        plot_height=800,
+        plot_width=figsize[0],
+        plot_height=figsize[1],
         output_backend="webgl",
         match_aspect=True,
         x_range=x_range,

--- a/postreise/plot/plot_upgrades_map.py
+++ b/postreise/plot/plot_upgrades_map.py
@@ -24,6 +24,7 @@ def _map_upgrades(
     figsize=(1400, 800),
     x_range=None,
     y_range=None,
+    plot_states_kwargs=None,
 ):
     """Makes map of branches showing upgrades
 
@@ -43,6 +44,8 @@ def _map_upgrades(
     :param tuple(int, int) figsize: size of the bokeh figure (in pixels).
     :param tuple(float, float) x_range: x range to zoom plot to (EPSG:3857).
     :param tuple(float, float) y_range: y range to zoom plot to (EPSG:3857).
+    :param dict plot_states_kwargs: keyword arguments to be passed to
+        :func:`postreise.plot.plot_states.plot_states`.
     :return: (*bokeh.plotting.figure.Figure*) -- Bokeh map plot of color-coded upgrades.
     """
     # plotting constants
@@ -199,14 +202,18 @@ def _map_upgrades(
 
     # Everything below gets plotted into the 'main' figure
     # state outlines
-    plot_states(
-        bokeh_figure=p,
-        colors="white",
-        line_color="slategrey",
-        line_width=1,
-        fill_alpha=1,
-        background_map=False,
-    )
+    default_plot_states_kwargs = {
+        "colors": "white",
+        "line_color": "slategrey",
+        "line_width": 1,
+        "fill_alpha": 1,
+        "background_map": False,
+    }
+    if plot_states_kwargs is not None:
+        all_plot_states_kwargs = default_plot_states_kwargs.update(**plot_states_kwargs)
+    else:
+        all_plot_states_kwargs = default_plot_states_kwargs
+    plot_states(bokeh_figure=p, **all_plot_states_kwargs)
 
     background_plot_dicts = [
         {"source": source_all_ac, "color": "gray", "line_width": "cap"},

--- a/postreise/plot/plot_upgrades_map.py
+++ b/postreise/plot/plot_upgrades_map.py
@@ -15,7 +15,7 @@ def _map_upgrades(
     branch_merge,
     dc_merge,
     state_shapes,
-    b2b_indices,
+    b2b_indices=None,
     diff_threshold=100,
     all_branch_scale=1e-3,
     diff_branch_scale=1e-3,
@@ -57,6 +57,7 @@ def _map_upgrades(
 
     # For these, we will plot a triangle for the B2B location, plus 'pseudo' AC lines
     # get_level_values allows us to index into MultiIndex as necessary
+    b2b_indices = {} if b2b_indices is None else b2b_indices
     b2b_mask = branch_dc.index.get_level_values(0).isin(b2b_indices)
     # .copy() avoids a pandas SettingWithCopyError later
     b2b = branch_dc.iloc[b2b_mask].copy()

--- a/postreise/plot/plot_upgrades_map.py
+++ b/postreise/plot/plot_upgrades_map.py
@@ -140,6 +140,7 @@ def _map_upgrades(
         plot_height=figsize[1],
         output_backend="webgl",
         match_aspect=True,
+        sizing_mode="scale_both",
         x_range=x_range,
         y_range=y_range,
     )

--- a/postreise/plot/plot_upgrades_map.py
+++ b/postreise/plot/plot_upgrades_map.py
@@ -20,7 +20,7 @@ def _map_upgrades(
     diff_branch_scale=1,
     all_branch_min=0.1,
     diff_branch_min=1.0,
-    b2b_scale=5e-3,
+    b2b_scale=5,
     figsize=(1400, 800),
     x_range=None,
     y_range=None,
@@ -40,7 +40,7 @@ def _map_upgrades(
     :param int/float all_branch_min: minimum width to plot all branches.
     :param int/float diff_branch_min: minimum width to plot branches with significant
         differences.
-    :param int/float b2b_scale: scale factor for plotting b2b facilities.
+    :param int/float b2b_scale: scale factor for plotting b2b facilities (pixels/GW).
     :param tuple(int, int) figsize: size of the bokeh figure (in pixels).
     :param tuple(float, float) x_range: x range to zoom plot to (EPSG:3857).
     :param tuple(float, float) y_range: y range to zoom plot to (EPSG:3857).
@@ -237,7 +237,7 @@ def _map_upgrades(
         y=b2b.from_y,
         color="gray",
         marker="triangle",
-        size=b2b["Pmax"].abs() * b2b_scale,
+        size=b2b["Pmax"].abs() * b2b_scale / 1000,
         alpha=all_elements_alpha,
     )
 
@@ -263,7 +263,7 @@ def _map_upgrades(
         y=b2b.from_y,
         color=colors.be_magenta,
         marker="triangle",
-        size=b2b["diff"].abs() * b2b_scale,
+        size=b2b["diff"].abs() * b2b_scale / 1000,
     )
 
     return p


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Allow transmission upgrades plots to be created using any interconnection, and to properly plot new branches as well as scaled branches.
Closes #267.

### What the code is doing
In **upgrades.py**: we fix the merging of the two branch data frames to ensure that the lat/lon columns of the merged data frame include the lat/lon data of new branches.

In **plot_upgrades_map.py**:
- We make use of the `plot_states` function to simplify border plotting.
- Previously-hardcoded b2b_indices are now passed by the user.
- Previously-hardcoded figure sizes can now be passed by the user (default sizing remains, which is good for plotting USA).
- The user can specify explicit `x_range` and `y_range`, to be able to zoom into certain regions.
- Scaling factors are now specified in pixels/GW, not pixels/MW, based on conversations in https://github.com/Breakthrough-Energy/PostREISE/pull/266.

### Testing
@danlivengood has been using this code to plot maps of Eastern scenarios with new branches.

### Time estimate
10 minutes. The data frame merge is the most complex part, most everything else is just adding flexibility to previously-hardcoded values.