### PR TITLE
chore: remove seaborn from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ pandas~=1.1.2
 -e ../PowerSimData
 pyproj==2.6.1.post1
 pytest==5.4.3
-seaborn==0.10.1


### PR DESCRIPTION
### Purpose
Cleanup from #243, removing `seaborn` package from requirements.txt that we don't actually require anymore.

### Time estimate
5 seconds.
