### PR TITLE
fix: correct bug where get_dcline_differences fails for DC lines connected to new buses

### DIFF
--- a/postreise/plot/plot_transmission_upgrades_map.py
+++ b/postreise/plot/plot_transmission_upgrades_map.py
@@ -290,7 +290,7 @@ def map_transmission_upgrades(scenario1, scenario2, b2b_indices=None, **plot_kwa
     grid1 = scenario1.state.get_grid()
     grid2 = scenario2.state.get_grid()
     branch_merge = get_branch_differences(grid1.branch, grid2.branch)
-    dc_merge = get_dcline_differences(grid1.dcline, grid2.dcline, grid1.bus)
+    dc_merge = get_dcline_differences(grid1, grid2)
     map_plot = _map_transmission_upgrades(
         branch_merge, dc_merge, b2b_indices, **plot_kwargs
     )


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Correct a bug where the `postreise.analyze.transmission.upgrades.get_dcline_differences` fails when comparing a grid with dclines connected to new buses. This also blocks the `postreise.plot.plot_transmission_upgrades_map.map_transmission_upgrades` function which relies on it.

### Demonstration of bug
```python
>>> from powersimdata import Scenario
>>> from bokeh.io import show
>>> from postreise.plot.plot_transmission_upgrades_map import map_transmission_upgrades
>>> show(map_transmission_upgrades(Scenario(2672), Scenario(3697)))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\DanielOlsen\repos\bes\PostREISE\postreise\plot\plot_transmission_upgrades_map.py", line 293, in map_transmission_upgrades
    dc_merge = get_dcline_differences(grid1.dcline, grid2.dcline, grid1.bus)
  File "C:\Users\DanielOlsen\repos\bes\PostREISE\postreise\analyze\transmission\upgrades.py", line 82, in get_dcline_differences
    dc_merge["from_lon"] = bus.loc[dc_merge.from_bus_id, "lon"].values
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 889, in __getitem__
    return self._getitem_tuple(key)
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 1060, in _getitem_tuple
    return self._getitem_lowerdim(tup)
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 831, in _getitem_lowerdim
    return getattr(section, self.name)[new_key]
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 895, in __getitem__
    return self._getitem_axis(maybe_callable, axis=axis)
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 1113, in _getitem_axis
    return self._getitem_iterable(key, axis=axis)
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 1053, in _getitem_iterable
    keyarr, indexer = self._get_listlike_indexer(key, axis, raise_missing=False)
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 1266, in _get_listlike_indexer
    self._validate_read_indexer(keyarr, indexer, axis, raise_missing=raise_missing)
  File "C:\Python38\lib\site-packages\pandas\core\indexing.py", line 1321, in _validate_read_indexer
    raise KeyError(
KeyError: "Passing list-likes to .loc or [] with any missing labels is no longer supported. The following labels were missing: Float64Index([2090024.0, 2090025.0, 2090026.0, 2090027.0, 2090028.0,\n              ...\n              2090041.0, 2090042.0, 2090043.0, 2090044.0, 2090045.0],\n             dtype='float64', name='bus_id', length=22). See https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike"
```

### What the code is doing
Previously, within `get_dcline_differences`, both `dcline` tables looked up latitudes and longitudes from the a single `bus` table, and the `map_transmission_upgrades` function passed the `bus` table corresponding to the first `dcline` table, which fails when the second `dcline` table points to buses that aren't in the first `bus` table. To fix this, we refactor the `get_dcline_differences` function to take two grids, and we look up the latitudes and longitudes from each corresponding `bus` table before merging the two `dcline` tables together to calculate the `Pmax` differences.

### Testing
Manually testing, the call that had failed before works:
```python
>>> from powersimdata import Scenario
>>> from bokeh.io import show
>>> from postreise.plot.plot_transmission_upgrades_map import map_transmission_upgrades
>>> show(map_transmission_upgrades(Scenario(2672), Scenario(3697)))
```
(does not fail)

### Time estimate
5-15 minutes.
