### PR TITLE
refactor: improve the flexibility of the transmission upgrades map

### DIFF
--- a/postreise/plot/plot_transmission_upgrades_map.py
+++ b/postreise/plot/plot_transmission_upgrades_map.py
@@ -24,8 +24,6 @@ def _map_transmission_upgrades(
     b2b_scale=5,
     dcline_upgrade_dist_threshold=0,
     plot_states_kwargs=None,
-    legend_font_size=20,
-    legend_location="bottom_left",
 ):
     """Make map of branches showing upgrades.
 
@@ -46,8 +44,6 @@ def _map_transmission_upgrades(
         plotting DC line upgrades (if none are longer, no legend entry will be created).
     :param dict plot_states_kwargs: keyword arguments to be passed to
         :func:`postreise.plot.plot_states.plot_states`.
-    :param int/float legend_font_size: font size for legend.
-    :param str legend_location: location for legend.
     :return: (*bokeh.plotting.figure.Figure*) -- Bokeh map plot of color-coded upgrades.
     """
     # plotting constants
@@ -192,8 +188,6 @@ def _map_transmission_upgrades(
             size=30,
             alpha=legend_alpha,
         )
-    p.legend.location = legend_location
-    p.legend.label_text_font_size = f"{legend_font_size}pt"
 
     # Everything below gets plotted into the 'main' figure
     # state outlines
@@ -270,6 +264,8 @@ def map_transmission_upgrades(
     figsize=(1400, 800),
     x_range=None,
     y_range=None,
+    legend_font_size=20,
+    legend_location="bottom_left",
     **plot_kwargs,
 ):
     """Plot capacity differences for branches & HVDC lines between two scenarios.
@@ -280,6 +276,8 @@ def map_transmission_upgrades(
     :param tuple figsize: size of the bokeh figure (in pixels).
     :param tuple x_range: x range to zoom plot to (EPSG:3857).
     :param tuple y_range: y range to zoom plot to (EPSG:3857).
+    :param int/float legend_font_size: font size for legend.
+    :param str legend_location: location for legend.
     :param \\*\\*plot_kwargs: collected keyword arguments to be passed to
         :func:`_map_transmission_upgrades`.
     :return: (*bokeh.plotting.figure.Figure*) -- Bokeh map plot of color-coded upgrades.
@@ -316,4 +314,8 @@ def map_transmission_upgrades(
     map_plot = _map_transmission_upgrades(
         branch_merge, dc_merge, b2b_indices, **plot_kwargs
     )
+
+    p.legend.location = legend_location
+    p.legend.label_text_font_size = f"{legend_font_size}pt"
+
     return map_plot

--- a/postreise/plot/plot_transmission_upgrades_map.py
+++ b/postreise/plot/plot_transmission_upgrades_map.py
@@ -268,6 +268,8 @@ def map_transmission_upgrades(
     :param str legend_location: location for legend.
     :param \\*\\*plot_kwargs: collected keyword arguments to be passed to
         :func:`add_transmission_upgrades`.
+    :raises ValueError: if ``scenario1`` and ``scenario2`` do not match both grid_model
+        and interconnect.
     :return: (*bokeh.plotting.figure.Figure*) -- Bokeh map plot of color-coded upgrades.
     """
     # Validate inputs

--- a/postreise/plot/plot_transmission_upgrades_map.py
+++ b/postreise/plot/plot_transmission_upgrades_map.py
@@ -25,6 +25,7 @@ def _map_transmission_upgrades(
     x_range=None,
     y_range=None,
     plot_states_kwargs=None,
+    legend_font_size=20,
 ):
     """Make map of branches showing upgrades.
 
@@ -46,6 +47,7 @@ def _map_transmission_upgrades(
     :param tuple y_range: y range to zoom plot to (EPSG:3857).
     :param dict plot_states_kwargs: keyword arguments to be passed to
         :func:`postreise.plot.plot_states.plot_states`.
+    :param int/float legend_font_size: font size for legend.
     :return: (*bokeh.plotting.figure.Figure*) -- Bokeh map plot of color-coded upgrades.
     """
     # plotting constants
@@ -202,7 +204,7 @@ def _map_transmission_upgrades(
             alpha=legend_alpha,
         )
     p.legend.location = "bottom_left"
-    p.legend.label_text_font_size = "20pt"
+    p.legend.label_text_font_size = f"{legend_font_size}pt"
 
     # Everything below gets plotted into the 'main' figure
     # state outlines

--- a/postreise/plot/plot_transmission_upgrades_map.py
+++ b/postreise/plot/plot_transmission_upgrades_map.py
@@ -23,7 +23,6 @@ def _map_transmission_upgrades(
     diff_branch_min=1.0,
     b2b_scale=5,
     dcline_upgrade_dist_threshold=0,
-    plot_states_kwargs=None,
 ):
     """Make map of branches showing upgrades.
 
@@ -42,8 +41,6 @@ def _map_transmission_upgrades(
     :param int/float b2b_scale: scale factor for plotting b2b facilities (pixels/GW).
     :param int/float dcline_upgrade_dist_threshold: minimum distance (miles) for
         plotting DC line upgrades (if none are longer, no legend entry will be created).
-    :param dict plot_states_kwargs: keyword arguments to be passed to
-        :func:`postreise.plot.plot_states.plot_states`.
     :return: (*bokeh.plotting.figure.Figure*) -- Bokeh map plot of color-coded upgrades.
     """
     # plotting constants
@@ -190,20 +187,6 @@ def _map_transmission_upgrades(
         )
 
     # Everything below gets plotted into the 'main' figure
-    # state outlines
-    default_plot_states_kwargs = {
-        "colors": "white",
-        "line_color": "slategrey",
-        "line_width": 1,
-        "fill_alpha": 1,
-        "background_map": False,
-    }
-    if plot_states_kwargs is not None:
-        all_plot_states_kwargs = {**default_plot_states_kwargs, **plot_states_kwargs}
-    else:
-        all_plot_states_kwargs = default_plot_states_kwargs
-    plot_states(bokeh_figure=p, **all_plot_states_kwargs)
-
     background_plot_dicts = [
         {"source": source_all_ac, "color": "gray", "line_width": "cap"},
         {"source": source_all_dc, "color": "gray", "line_width": "cap"},
@@ -264,6 +247,7 @@ def map_transmission_upgrades(
     figsize=(1400, 800),
     x_range=None,
     y_range=None,
+    plot_states_kwargs=None,
     legend_font_size=20,
     legend_location="bottom_left",
     **plot_kwargs,
@@ -276,6 +260,8 @@ def map_transmission_upgrades(
     :param tuple figsize: size of the bokeh figure (in pixels).
     :param tuple x_range: x range to zoom plot to (EPSG:3857).
     :param tuple y_range: y range to zoom plot to (EPSG:3857).
+    :param dict plot_states_kwargs: keyword arguments to be passed to
+        :func:`postreise.plot.plot_states.plot_states`.
     :param int/float legend_font_size: font size for legend.
     :param str legend_location: location for legend.
     :param \\*\\*plot_kwargs: collected keyword arguments to be passed to
@@ -310,6 +296,20 @@ def map_transmission_upgrades(
     )
     p.xgrid.visible = False
     p.ygrid.visible = False
+
+    # Add state outlines
+    default_plot_states_kwargs = {
+        "colors": "white",
+        "line_color": "slategrey",
+        "line_width": 1,
+        "fill_alpha": 1,
+        "background_map": False,
+    }
+    if plot_states_kwargs is not None:
+        all_plot_states_kwargs = {**default_plot_states_kwargs, **plot_states_kwargs}
+    else:
+        all_plot_states_kwargs = default_plot_states_kwargs
+    plot_states(bokeh_figure=p, **all_plot_states_kwargs)
 
     map_plot = _map_transmission_upgrades(
         branch_merge, dc_merge, b2b_indices, **plot_kwargs

--- a/postreise/plot/plot_transmission_upgrades_map.py
+++ b/postreise/plot/plot_transmission_upgrades_map.py
@@ -12,7 +12,8 @@ from postreise.plot.plot_states import plot_states
 from postreise.plot.projection_helpers import project_branch
 
 
-def _map_transmission_upgrades(
+def add_transmission_upgrades(
+    bokeh_figure,
     branch_merge,
     dc_merge,
     b2b_indices=None,
@@ -26,6 +27,7 @@ def _map_transmission_upgrades(
 ):
     """Make map of branches showing upgrades.
 
+    :param bokeh.plotting.figure.Figure bokeh_figure: figure to add upgrades to.
     :param pandas.DataFrame branch_merge: branch of scenarios 1 and 2
     :param pandas.DataFrame dc_merge: dclines for scenarios 1 and 2
     :param list/set/tuple b2b_indices: indices of HVDC lines which are back-to-backs.
@@ -140,7 +142,7 @@ def _map_transmission_upgrades(
 
     # These are 'dummy' series to populate the legend with
     if len(branch_dc_lines[branch_dc_lines["diff"] > 0]) > 0:
-        p.multi_line(
+        bokeh_figure.multi_line(
             leg_x,
             leg_y,
             color=colors.be_green,
@@ -149,7 +151,7 @@ def _map_transmission_upgrades(
             legend_label="Additional HVDC Capacity",
         )
     if len(branch_dc_lines[branch_dc_lines["diff"] < 0]) > 0:
-        p.multi_line(
+        bokeh_figure.multi_line(
             leg_x,
             leg_y,
             color=colors.be_lightblue,
@@ -158,7 +160,7 @@ def _map_transmission_upgrades(
             legend_label="Reduced HVDC Capacity",
         )
     if len(branch_all[branch_all["diff"] < 0]) > 0:
-        p.multi_line(
+        bokeh_figure.multi_line(
             leg_x,
             leg_y,
             color=colors.be_purple,
@@ -167,7 +169,7 @@ def _map_transmission_upgrades(
             legend_label="Reduced AC Transmission",
         )
     if len(branch_all[branch_all["diff"] > 0]) > 0:
-        p.multi_line(
+        bokeh_figure.multi_line(
             leg_x,
             leg_y,
             color=colors.be_blue,
@@ -176,7 +178,7 @@ def _map_transmission_upgrades(
             legend_label="Upgraded AC transmission",
         )
     if len(b2b[b2b["diff"] > 0]) > 0:
-        p.scatter(
+        bokeh_figure.scatter(
             x=b2b.from_x[1],
             y=b2b.from_y[1],
             color=colors.be_magenta,
@@ -193,7 +195,7 @@ def _map_transmission_upgrades(
         {"source": source_pseudoac, "color": "gray", "line_width": "cap"},
     ]
     for d in background_plot_dicts:
-        p.multi_line(
+        bokeh_figure.multi_line(
             "xs",
             "ys",
             color=d["color"],
@@ -203,7 +205,7 @@ def _map_transmission_upgrades(
         )
 
     # all B2Bs
-    p.scatter(
+    bokeh_figure.scatter(
         x=b2b.from_x,
         y=b2b.from_y,
         color="gray",
@@ -219,7 +221,7 @@ def _map_transmission_upgrades(
     ]
 
     for d in difference_plot_dicts:
-        p.multi_line(
+        bokeh_figure.multi_line(
             "xs",
             "ys",
             color=d["color"],
@@ -229,7 +231,7 @@ def _map_transmission_upgrades(
         )
 
     # B2Bs with differences
-    p.scatter(
+    bokeh_figure.scatter(
         x=b2b.from_x,
         y=b2b.from_y,
         color=colors.be_magenta,
@@ -237,7 +239,7 @@ def _map_transmission_upgrades(
         size=b2b["diff"].abs() * b2b_scale_MW,
     )
 
-    return p
+    return bokeh_figure
 
 
 def map_transmission_upgrades(
@@ -265,7 +267,7 @@ def map_transmission_upgrades(
     :param int/float legend_font_size: font size for legend.
     :param str legend_location: location for legend.
     :param \\*\\*plot_kwargs: collected keyword arguments to be passed to
-        :func:`_map_transmission_upgrades`.
+        :func:`add_transmission_upgrades`.
     :return: (*bokeh.plotting.figure.Figure*) -- Bokeh map plot of color-coded upgrades.
     """
     # Validate inputs
@@ -311,8 +313,8 @@ def map_transmission_upgrades(
         all_plot_states_kwargs = default_plot_states_kwargs
     plot_states(bokeh_figure=p, **all_plot_states_kwargs)
 
-    map_plot = _map_transmission_upgrades(
-        branch_merge, dc_merge, b2b_indices, **plot_kwargs
+    map_plot = add_transmission_upgrades(
+        p, branch_merge, dc_merge, b2b_indices, **plot_kwargs
     )
 
     p.legend.location = legend_location

--- a/postreise/plot/plot_transmission_upgrades_map.py
+++ b/postreise/plot/plot_transmission_upgrades_map.py
@@ -26,6 +26,7 @@ def _map_transmission_upgrades(
     y_range=None,
     plot_states_kwargs=None,
     legend_font_size=20,
+    legend_location="bottom_left",
 ):
     """Make map of branches showing upgrades.
 
@@ -48,6 +49,7 @@ def _map_transmission_upgrades(
     :param dict plot_states_kwargs: keyword arguments to be passed to
         :func:`postreise.plot.plot_states.plot_states`.
     :param int/float legend_font_size: font size for legend.
+    :param str legend_location: location for legend.
     :return: (*bokeh.plotting.figure.Figure*) -- Bokeh map plot of color-coded upgrades.
     """
     # plotting constants
@@ -203,7 +205,7 @@ def _map_transmission_upgrades(
             size=30,
             alpha=legend_alpha,
         )
-    p.legend.location = "bottom_left"
+    p.legend.location = legend_location
     p.legend.label_text_font_size = f"{legend_font_size}pt"
 
     # Everything below gets plotted into the 'main' figure


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
- Change hard-coded values to user-facing parameters with default values.
- Separate the init of a bokeh figure from the addition of upgrades information.
- Add a parameter to filter display of DC line additions by length
- Add parameter to control legend display

### What the code is doing
The only effective code change is allowing the user to filter the display of DC lines by minimum length, and to allow the user to size and locate the legend. All other changes are just reorganization of the code.

### Testing
Tested manually, still works.

### Time estimate
15 minutes.