### PR TITLE
Simplify process to generate plotting documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+This guide will demonstrate how to regenerate the plots used in the documentation here.
+The requirements are
+1) Have docker installed
+2) Download the [PlotData] zip file containing the scenarios used
+
+Next, extract the data to your home directory, or change the expected location in the
+docker-compose.yml file.
+
+
+Start the container, which will provide a notebook environment for running the code
+snippets.
+```
+docker compose up
+```
+
+After copying the notebook url from the output, start the `run_snippets.ipynb` notebook
+and run through it. For the most part, no interaction is required. The exception is any
+bokeh plots which must be manually saved as png (currently only the powerflow snapshot). 
+
+One may notice that the first part of the notebook contains code to generate the cells
+used subsequently. This is due to (as far as I know) lack of support in jupyterlab for
+programmatically adding new cells, so as a result, any changes to the configuration may
+require a developer to rerun this part and copy/paste the output as needed. In most
+cases, one can simply run it with no changes, since the notebook is pre-populated.
+
+The output from each snippet will be saved in the `img2/` directory, similar to `img/` which 
+is checked into git. From here, it's up to the user to compare results and commit the new plots if they look
+good.
+
+[PlotData]: https://besciences.blob.core.windows.net/snapshots/PlotData.zip

--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.7'
+
+services:
+  postreise:
+    container_name: postreise
+    hostname: postreise
+    image: ghcr.io/breakthrough-energy/postreise:latest
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t
+    working_dir: /app
+    volumes:
+      - ~/PlotData:/mnt/bes/pcm
+      - ./:/app
+    ports:
+      - "10000:10000"
+    environment:
+      - DEPLOYMENT_MODE=1

--- a/docs/helper.py
+++ b/docs/helper.py
@@ -1,0 +1,33 @@
+mpl = {
+    "single": {
+        "curtailment_eastern": (
+            "curtailment_solar_eastern_ts.png",
+            "curtailment_wind_eastern_ts.png",
+        ),
+        "capacity_vs_cf_solar_western_scatter": "capacity_vs_cf_solar_western_scatter.png",
+        "capacity_vs_cost_curve_slope_coal_eastern_scatter": "capacity_vs_cost_curve_slope_coal_eastern_scatter.png",
+        "capacity_vs_curtailment_solar_western_scatter": "capacity_vs_curtailment_solar_western_scatter.png",
+        "curtailment_usa_heatmap": "curtailment_usa_heatmap.png",
+        "generation_stack_western_ts": "generation_stack_western_ts.png",
+    },
+    "comp": {
+        "capacity_vs_generation_bar": (
+            "capacity_vs_generation_ca_bar.png",
+            "capacity_vs_generation_western_bar.png",
+        ),
+        "capacity_vs_generation_pie": (
+            "capacity_vs_generation_wa_pie.png",
+            "capacity_vs_generation_western_pie.png",
+        ),
+        "energy_emission_stack_bar": "energy_emission_stack_bar.png",
+        "shortfall_nv": "shortfall_nv.png",
+        "emission_bar": "emission_bar.png",
+        "shortfall_nv": "shortfall_nv.png",
+    },
+}
+
+
+def save_matplotlib(result, filename):
+    for i, output in enumerate(result.outputs):
+        with open(filename[i], "wb") as f:
+            f.write(output.data["image/png"])

--- a/docs/helper.py
+++ b/docs/helper.py
@@ -1,4 +1,4 @@
-mpl = {
+mpl_config = {
     "single": {
         "curtailment_eastern": (
             "curtailment_solar_eastern_ts.png",
@@ -24,6 +24,17 @@ mpl = {
         "emission_bar": "emission_bar.png",
         "shortfall_nv": "shortfall_nv.png",
     },
+}
+
+bokeh_config = {
+    "single": {
+        "lmp_usa_map": "lmp_usa_map.html",
+        "utilization_map": "utilization_map.html",
+        "emission_map": "emission_map.html",
+        "pf_snapshot_map": "pf_snapshot_map.png",
+    },
+    "other": {"interconnection_map": "interconnection_map.html"},
+    "comp": {"emission_map_carbon_diff": "emission_map.html"},
 }
 
 

--- a/docs/run_snippets.ipynb
+++ b/docs/run_snippets.ipynb
@@ -1,0 +1,408 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bcde2b26-c5f9-4cbb-a12a-059d550563bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "# from bokeh.io import output_notebook\n",
+    "# output_notebook()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3e7eab87-e8de-4ed4-bbf6-6029d00895ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.makedirs(\"img2\", exist_ok=True)\n",
+    "os.makedirs(\"img2/single\", exist_ok=True)\n",
+    "os.makedirs(\"img2/comp\", exist_ok=True)\n",
+    "os.makedirs(\"img2/other\", exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "32f8c42f-5d68-4ed9-ad93-2976f02f6c70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %load helper.py\n",
+    "mpl = {\n",
+    "    \"single\": {\n",
+    "        \"curtailment_eastern\": (\n",
+    "            \"curtailment_solar_eastern_ts.png\",\n",
+    "            \"curtailment_wind_eastern_ts.png\",\n",
+    "        ),\n",
+    "        \"capacity_vs_cf_solar_western_scatter\": \"capacity_vs_cf_solar_western_scatter.png\",\n",
+    "        \"capacity_vs_cost_curve_slope_coal_eastern_scatter\": \"capacity_vs_cost_curve_slope_coal_eastern_scatter.png\",\n",
+    "        \"capacity_vs_curtailment_solar_western_scatter\": \"capacity_vs_curtailment_solar_western_scatter.png\",\n",
+    "        \"curtailment_usa_heatmap\": \"curtailment_usa_heatmap.png\",\n",
+    "        \"generation_stack_western_ts\": \"generation_stack_western_ts.png\",\n",
+    "    },\n",
+    "    \"comp\": {\n",
+    "        \"capacity_vs_generation_bar\": (\n",
+    "            \"capacity_vs_generation_ca_bar.png\",\n",
+    "            \"capacity_vs_generation_western_bar.png\",\n",
+    "        ),\n",
+    "        \"capacity_vs_generation_pie\": (\n",
+    "            \"capacity_vs_generation_wa_pie.png\",\n",
+    "            \"capacity_vs_generation_western_pie.png\",\n",
+    "        ),\n",
+    "        \"energy_emission_stack_bar\": \"energy_emission_stack_bar.png\",\n",
+    "        \"shortfall_nv\": \"shortfall_nv.png\",\n",
+    "        \"emission_bar\": \"emission_bar.png\",\n",
+    "        \"shortfall_nv\": \"shortfall_nv.png\",\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def save_matplotlib(result, filename):\n",
+    "    for i, output in enumerate(result.outputs):\n",
+    "        with open(filename[i], \"wb\") as f:\n",
+    "            f.write(output.data[\"image/png\"])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7c471324-d191-495b-93f8-50252d30fa57",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "%%capture result\n",
+      "%run code/curtailment_eastern.py\n",
+      "save_matplotlib(result, ('img2/single/curtailment_solar_eastern_ts.png', 'img2/single/curtailment_wind_eastern_ts.png'))\n",
+      "\n",
+      "%%capture result\n",
+      "%run code/capacity_vs_cf_solar_western_scatter.py\n",
+      "save_matplotlib(result, ('img2/single/capacity_vs_cf_solar_western_scatter.png',))\n",
+      "\n",
+      "%%capture result\n",
+      "%run code/capacity_vs_cost_curve_slope_coal_eastern_scatter.py\n",
+      "save_matplotlib(result, ('img2/single/capacity_vs_cost_curve_slope_coal_eastern_scatter.png',))\n",
+      "\n",
+      "%%capture result\n",
+      "%run code/capacity_vs_curtailment_solar_western_scatter.py\n",
+      "save_matplotlib(result, ('img2/single/capacity_vs_curtailment_solar_western_scatter.png',))\n",
+      "\n",
+      "%%capture result\n",
+      "%run code/curtailment_usa_heatmap.py\n",
+      "save_matplotlib(result, ('img2/single/curtailment_usa_heatmap.png',))\n",
+      "\n",
+      "%%capture result\n",
+      "%run code/generation_stack_western_ts.py\n",
+      "save_matplotlib(result, ('img2/single/generation_stack_western_ts.png',))\n",
+      "\n",
+      "%%capture result\n",
+      "%run code/capacity_vs_generation_bar.py\n",
+      "save_matplotlib(result, ('img2/comp/capacity_vs_generation_ca_bar.png', 'img2/comp/capacity_vs_generation_western_bar.png'))\n",
+      "\n",
+      "%%capture result\n",
+      "%run code/capacity_vs_generation_pie.py\n",
+      "save_matplotlib(result, ('img2/comp/capacity_vs_generation_wa_pie.png', 'img2/comp/capacity_vs_generation_western_pie.png'))\n",
+      "\n",
+      "%%capture result\n",
+      "%run code/energy_emission_stack_bar.py\n",
+      "save_matplotlib(result, ('img2/comp/energy_emission_stack_bar.png',))\n",
+      "\n",
+      "%%capture result\n",
+      "%run code/shortfall_nv.py\n",
+      "save_matplotlib(result, ('img2/comp/shortfall_nv.png',))\n",
+      "\n",
+      "%%capture result\n",
+      "%run code/emission_bar.py\n",
+      "save_matplotlib(result, ('img2/comp/emission_bar.png',))\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "def generate_cells():\n",
+    "    capture = \"%%capture result\"        \n",
+    "    for kind, info in mpl.items():\n",
+    "        for snippet, img_file in info.items():\n",
+    "            if not isinstance(img_file, tuple):\n",
+    "                img_file = (img_file,)\n",
+    "            run_cmd = f\"%run code/{snippet}.py\"\n",
+    "            filename = tuple(f\"img2/{kind}/{f}\" for f in img_file)\n",
+    "            save_cmd = f\"save_matplotlib(result, {filename})\"\n",
+    "            print(f\"{capture}\\n{run_cmd}\\n{save_cmd}\\n\")\n",
+    "\n",
+    "generate_cells()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "86901faa-e41a-4936-ab00-54431777215a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture result\n",
+    "%run code/curtailment_eastern.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "020558b9-0f52-4fd1-a19e-6926be37c076",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_matplotlib(result, ('img2/single/curtailment_solar_eastern_ts.png', 'img2/single/curtailment_wind_eastern_ts.png'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "3d334262-e106-47a7-bcfe-0aa615823696",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture result\n",
+    "%run code/capacity_vs_cf_solar_western_scatter.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8fb1ecfd-1f67-4fed-b3a1-5c8f826e6fb1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_matplotlib(result, ('img2/single/capacity_vs_cf_solar_western_scatter.png',))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c16201e5-7bd4-4b0b-adbf-3909cb149b99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture result\n",
+    "%run code/capacity_vs_cost_curve_slope_coal_eastern_scatter.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f34e1367-0c13-4639-8928-2420a2d0fb97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_matplotlib(result, ('img2/single/capacity_vs_cost_curve_slope_coal_eastern_scatter.png',))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "d9bdcaf4-9277-4565-8ddc-fbb2a7dd7d0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture result\n",
+    "%run code/capacity_vs_curtailment_solar_western_scatter.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "06374224-422d-425e-82c9-dac8a3dfb193",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_matplotlib(result, ('img2/single/capacity_vs_curtailment_solar_western_scatter.png',))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "be19746d-1a94-49b3-b2f6-3f78e91bccd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture result\n",
+    "%run code/curtailment_usa_heatmap.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "049493cd-e880-46a5-8cec-066ac978c329",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_matplotlib(result, ('img2/single/curtailment_usa_heatmap.png',))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b620686a-bbf8-43c7-987c-dd54bba79b4e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%capture result\n",
+    "%run code/generation_stack_western_ts.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "6d0356be-2c65-481e-a2ab-b1323b1586a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_matplotlib(result, ('img2/single/generation_stack_western_ts.png',))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "70114138-c06d-4b32-b8c3-9c20eb9f42b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture result\n",
+    "%run code/capacity_vs_generation_bar.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "fdbcdf4f-5867-4daa-a37a-4afee48aca3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_matplotlib(result, ('img2/comp/capacity_vs_generation_ca_bar.png', 'img2/comp/capacity_vs_generation_western_bar.png'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "485f0c7e-7126-4e58-ad67-d959e68456ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture result\n",
+    "%run code/capacity_vs_generation_pie.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "69572e86-949c-4a3f-bb4c-e1a75549697b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_matplotlib(result, ('img2/comp/capacity_vs_generation_wa_pie.png', 'img2/comp/capacity_vs_generation_western_pie.png'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "7e1243c1-98f5-47c6-8d91-7d6893d5b71e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture result\n",
+    "%run code/energy_emission_stack_bar.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "9d9754a5-d2bb-4211-8969-90eb60b3e8b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_matplotlib(result, ('img2/comp/energy_emission_stack_bar.png',))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "21424a05-568c-4d55-81aa-df67da65cb3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture result\n",
+    "%run code/shortfall_nv.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "7507e374-e0b5-4b50-a508-c18d01525120",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_matplotlib(result, ('img2/comp/shortfall_nv.png',))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "08978c6d-0650-48d1-91ae-5047765f7963",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture result\n",
+    "%run code/emission_bar.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "1d13a87a-996b-44b0-9cfb-2d55c64e136a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_matplotlib(result, ('img2/comp/emission_bar.png',))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ab44879-5023-4fdb-88d6-20cbdc80b764",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Purpose
The plots used on the docs website require specific scenarios as well as an environment to run the code snippets. The goal here is to simplify that as much as possible, so we can recreate the content as needed, e.g. to take advantage of new functionality.

### What the code is doing
What's involved:
* zip file with scenario data uploaded to blob storage
* docker-compose file for self contained environment
* notebook which generates the code used to run/save each code snippet

### Testing
I ran the notebook and compared the results with currently checked in files. There are a few minor differences, but that is due to inconsistencies in the code snippets, which we can fix separately if needed. 

### Usage Example/Visuals
If github will render the notebook, that is probably the most useful place to look

### Time estimate
20 min
