### PR TITLE
fix: remove filter on coverage measurement

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,2 @@
 [run]
 branch = True
-omit =
-    **/test_*.py
-    **/__init__.py
-


### PR DESCRIPTION
### Purpose
We forgot to update the config here, so coverage is appearing lower than it should (at least relative to the other repos).

### What the code is doing
Stop excluding test files in the measurement.

### Testing
n/a

### Time estimate
1 min
