### PR TITLE
refactor: get bus_demand via Scenario method instead of import

### DIFF
--- a/postreise/analyze/transmission/congestion.py
+++ b/postreise/analyze/transmission/congestion.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 from powersimdata.input.helpers import summarize_plant_to_bus
-from powersimdata.input.input_data import get_bus_demand
 from powersimdata.scenario.analyze import Analyze
 from powersimdata.scenario.scenario import Scenario
 
@@ -22,7 +21,7 @@ def calculate_congestion_surplus(scenario):
     lmp = scenario.state.get_lmp()
     pg = scenario.state.get_pg()
 
-    bus_demand = get_bus_demand(scenario.info, grid).to_numpy()
+    bus_demand = scenario.get_bus_demand()
     bus_pg = summarize_plant_to_bus(pg, grid, all_buses=True)
 
     congestion_surplus = (lmp.to_numpy() * (bus_demand - bus_pg)).sum(axis=1)

--- a/postreise/analyze/transmission/tests/test_congestion_surplus.py
+++ b/postreise/analyze/transmission/tests/test_congestion_surplus.py
@@ -1,10 +1,8 @@
 import numpy as np
 import pandas as pd
-import pytest
-from powersimdata.input.input_data import InputData
 from powersimdata.tests.mock_scenario import MockScenario
 
-# from postreise.analyze.transmission import congestion
+from postreise.analyze.transmission import congestion
 
 mock_plant = {
     "plant_id": ["A", "B", "C", "D"],
@@ -28,22 +26,15 @@ def _check_return(expected_return, surplus):
     np.testing.assert_array_equal(surplus.to_numpy(), expected_return.to_numpy(), msg)
 
 
-@pytest.mark.skip(reason="Test fails due to PowerSimData changes, will be updated")
-def test_calculate_congestion_surplus_single_time(monkeypatch):
+def test_calculate_congestion_surplus_single_time():
     """Congested case from Kirschen & Strbac Section 5.3.2.4"""
 
-    def mock_get_data(*args, **kwargs):
-        return demand
-
-    # Override default InputData.get_data method to avoid profile csv lookup
-    monkeypatch.setattr(InputData, "get_data", mock_get_data)
-
-    demand = pd.DataFrame({"UTC": ["t1"], 1: [410], 2: [0]})
+    bus_demand = pd.DataFrame({"UTC": ["t1"], 1: [50], 2: [60], 3: [300], 4: [0]})
     lmp = pd.DataFrame({"UTC": ["t1"], 1: [7.5], 2: [11.25], 3: [10], 4: [0]})
     pg = pd.DataFrame({"UTC": ["t1"], "A": [50], "B": [285], "C": [0], "D": [75]})
-    for df in (demand, lmp, pg):
+    for df in (bus_demand, lmp, pg):
         df.set_index("UTC", inplace=True)
-    mock_scenario = MockScenario(grid_attrs, demand=demand, lmp=lmp, pg=pg)
+    mock_scenario = MockScenario(grid_attrs, bus_demand=bus_demand, lmp=lmp, pg=pg)
 
     expected_return = pd.Series(
         data=[787.5],
@@ -51,22 +42,17 @@ def test_calculate_congestion_surplus_single_time(monkeypatch):
     )
     expected_return.rename_axis("UTC")
 
-    surplus = congestion.calculate_congestion_surplus(mock_scenario)  # noqa: F821
+    surplus = congestion.calculate_congestion_surplus(mock_scenario)
     _check_return(expected_return, surplus)
 
 
-@pytest.mark.skip(reason="Test fails due to PowerSimData changes, will be updated")
-def test_calculate_congestion_surplus_three_times(monkeypatch):
+def test_calculate_congestion_surplus_three_times():
     """First: congested. Second: uncongested. Third: uncongested, fuzzy."""
 
-    def mock_get_data(*args, **kwargs):
-        return demand
-
-    # Override default InputData.get_data method to avoid profile csv lookup
-    monkeypatch.setattr(InputData, "get_data", mock_get_data)
-
     time_indices = ["t1", "t2", "t3"]
-    demand = pd.DataFrame({"UTC": time_indices, 1: [410] * 3, 2: [0] * 3})
+    bus_demand = pd.DataFrame(
+        {"UTC": time_indices, 1: [50] * 3, 2: [60] * 3, 3: [300] * 3, 4: [0] * 3}
+    )
     lmp = pd.DataFrame(
         {
             "UTC": time_indices,
@@ -85,9 +71,9 @@ def test_calculate_congestion_surplus_three_times(monkeypatch):
             "D": [75, 0, 0],
         }
     )
-    for df in (demand, lmp, pg):
+    for df in (bus_demand, lmp, pg):
         df.set_index("UTC", inplace=True)
-    mock_scenario = MockScenario(grid_attrs, demand=demand, lmp=lmp, pg=pg)
+    mock_scenario = MockScenario(grid_attrs, bus_demand=bus_demand, lmp=lmp, pg=pg)
 
     expected_return = pd.Series(
         data=[787.5, 0, 0],
@@ -95,5 +81,5 @@ def test_calculate_congestion_surplus_three_times(monkeypatch):
     )
     expected_return.rename_axis("UTC")
 
-    surplus = congestion.calculate_congestion_surplus(mock_scenario)  # noqa: F821
+    surplus = congestion.calculate_congestion_surplus(mock_scenario)
     _check_return(expected_return, surplus)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Get `bus_demand` via the `Scenario.get_bus_demand()` method instead of importing the `get_bus_demand` function, which is being removed in https://github.com/Breakthrough-Energy/PowerSimData/pull/581. Closes https://github.com/Breakthrough-Energy/PostREISE/issues/327.

### Testing
Tested manually. With the PowerSimData branch for the PR installed:
```python
>>> from powersimdata import Scenario
>>> from postreise.analyze.transmission.congestion import calculate_congestion_surplus
>>> calculate_congestion_surplus(Scenario(3873))
UTC
2016-10-01 00:00:00    272789.533136
2016-10-01 01:00:00    272558.733281
2016-10-01 02:00:00    252855.877419
2016-10-01 03:00:00    248522.565691
2016-10-01 04:00:00    231332.804519
                           ...
2016-10-31 19:00:00    519741.613030
2016-10-31 20:00:00    554901.191273
2016-10-31 21:00:00    533267.041210
2016-10-31 22:00:00    456426.344775
2016-10-31 23:00:00    416862.087360
Freq: H, Length: 744, dtype: float64
```

### Time estimate
1 minute.
