### PR TITLE
Clean up tox file and fix warnings

### DIFF
--- a/postreise/analyze/demand.py
+++ b/postreise/analyze/demand.py
@@ -22,7 +22,7 @@ def get_demand_time_series(scenario, area, area_type=None):
     )
     loadzone_id_set = {grid.zone2id[lz] for lz in loadzone_set if lz in grid.zone2id}
 
-    return scenario.state.get_demand()[loadzone_id_set].sum(axis=1)
+    return scenario.state.get_demand()[list(loadzone_id_set)].sum(axis=1)
 
 
 def get_net_demand_time_series(scenario, area, area_type=None):

--- a/postreise/analyze/generation/curtailment.py
+++ b/postreise/analyze/generation/curtailment.py
@@ -30,11 +30,13 @@ def calculate_curtailment_time_series(scenario):
     grid = scenario.state.get_grid()
     pg = scenario.state.get_pg()
 
-    plant_id = get_plant_id_for_resources(
-        grid.model_immutables.plants["renewable_resources"].intersection(
-            set(grid.plant.type)
-        ),
-        grid,
+    plant_id = list(
+        get_plant_id_for_resources(
+            grid.model_immutables.plants["renewable_resources"].intersection(
+                set(grid.plant.type)
+            ),
+            grid,
+        )
     )
     profiles = pd.concat(
         [scenario.state.get_solar(), scenario.state.get_wind()], axis=1
@@ -120,7 +122,7 @@ def calculate_curtailment_percentage_by_resources(scenario, resources=None):
 
     curtailment_percentage = (
         sum(v for v in total_curtailment.values())
-        / total_potential.loc[resources].sum()
+        / total_potential.loc[list(resources)].sum()
     )
 
     return curtailment_percentage

--- a/postreise/analyze/generation/summarize.py
+++ b/postreise/analyze/generation/summarize.py
@@ -139,7 +139,7 @@ def summarize_hist_gen(
     result.loc["Texas interconnection"] = ercot
     result.loc["All"] = all
 
-    result = result.loc[:, filtered_colnames]
+    result = result.loc[:, list(filtered_colnames)]
     result.rename(columns=mi.plants["type2label"], inplace=True)
 
     return result

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,6 @@ envlist = pytest, format, flake8
 skipsdist = true
 
 [testenv]
-passenv =
-    CPPFLAGS
-    LDFLAGS
 deps =
     pytest: pipenv
     {format,checkformatting}: black


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Clean up ***tox.ini*** file and fix warnings raised by the test suite

### What the code is doing
Convert `set` to `list` when using indexer in data frame to fix `pandas`' `FutureWarning: Passing a set as an indexer is deprecated and will raise in a future version. Use a list instead`

### Testing
Run `tox` successfully

Remaining warnings come from `owersimdata/input/helpers.py` (l. 277) that has been fixed in https://github.com/Breakthrough-Energy/PowerSimData/pull/609 and will propagate in **PostREISE** the next time we release **PowerSimData**

### Where to look
* Remove unnecessary environment variables in ***tox.ini*** file
* Several modules where data frame are queried using `set`

### Usage Example/Visuals
N/A

### Time estimate
2 min
