### PR TITLE
Remove obsolete module

### DIFF
--- a/postreise/analyze/transmission/upgrades.py
+++ b/postreise/analyze/transmission/upgrades.py
@@ -1,6 +1,0 @@
-# These imports are maintained only for backwards-compatibility purposes
-from powersimdata.design.compare.helpers import _reindex_as_necessary  # noqa: F401
-from powersimdata.design.compare.transmission import (  # noqa: F401
-    calculate_branch_difference,
-    calculate_dcline_difference,
-)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Remove obsolete module

### What the code is doing
N/A

### Testing
Run `tox` successfully

### Where to look
The `calculate_branch_difference` and `calculate_dcline_difference` functions have been moved into `powersimdata.design.compare.transmission`. The `postreise.analyze.transmission.upgrades` module is never imported in **PostREISE**

### Usage Example/Visuals
N/A

### Time estimate
2 min
