### PR TITLE
Improve Code Coverage

### DIFF
--- a/postreise/analyze/demand.py
+++ b/postreise/analyze/demand.py
@@ -16,13 +16,13 @@ def get_demand_time_series(scenario, area, area_type=None):
     :return: (*pandas.Series*) -- time series of total demand, index: time stamps,
         column: demand values
     """
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
     loadzone_set = area_to_loadzone(
         scenario.info["grid_model"], area, area_type=area_type
     )
     loadzone_id_set = {grid.zone2id[lz] for lz in loadzone_set if lz in grid.zone2id}
 
-    return scenario.state.get_demand()[list(loadzone_id_set)].sum(axis=1)
+    return scenario.get_demand()[list(loadzone_id_set)].sum(axis=1)
 
 
 def get_net_demand_time_series(scenario, area, area_type=None):

--- a/postreise/analyze/generation/costs.py
+++ b/postreise/analyze/generation/costs.py
@@ -29,8 +29,8 @@ def calculate_costs(
         raise ValueError("Either scenario XOR (pg AND gencost) must be specified")
     if scenario is not None:
         _check_scenario_is_in_analyze_state(scenario)
-        pg = scenario.state.get_pg()
-        gencost = scenario.state.get_grid().gencost["before"]
+        pg = scenario.get_pg()
+        gencost = scenario.get_grid().gencost["before"]
     else:
         _check_gencost(gencost)
         _check_time_series(pg, "PG")

--- a/postreise/analyze/generation/curtailment.py
+++ b/postreise/analyze/generation/curtailment.py
@@ -181,8 +181,8 @@ def calculate_curtailment_time_series_by_resources_and_areas(
     :param dict areas: keys are area types ('*loadzone*', '*state*' or
         '*interconnect*'), values are a list of areas. Default is the scenario
         interconnect(s).
-    :return: (*dict*) -- keys are areas, values are dictionaries whose keys are
-        resources and values are data frames indexed by (timestamp, plant id).
+    :return: (*dict*) -- keys are resources, values are dictionaries whose keys are
+        areas and values are data frames indexed by (timestamp, plant id).
     """
     curtailment = calculate_curtailment_time_series(scenario)
     grid = scenario.state.get_grid()

--- a/postreise/analyze/generation/curtailment.py
+++ b/postreise/analyze/generation/curtailment.py
@@ -27,8 +27,8 @@ def calculate_curtailment_time_series(scenario):
     :return: (*pandas.DataFrame*) -- time series of curtailment.
     """
     _check_scenario_is_in_analyze_state(scenario)
-    grid = scenario.state.get_grid()
-    pg = scenario.state.get_pg()
+    grid = scenario.get_grid()
+    pg = scenario.get_pg()
 
     plant_id = list(
         get_plant_id_for_resources(
@@ -38,9 +38,7 @@ def calculate_curtailment_time_series(scenario):
             grid,
         )
     )
-    profiles = pd.concat(
-        [scenario.state.get_solar(), scenario.state.get_wind()], axis=1
-    )
+    profiles = pd.concat([scenario.get_solar(), scenario.get_wind()], axis=1)
 
     curtailment = (profiles[plant_id] - pg[plant_id]).clip(lower=0).round(6)
     return curtailment
@@ -56,7 +54,7 @@ def calculate_curtailment_time_series_by_resources(scenario, resources=None):
         (datetime, plant id).
     """
     curtailment = calculate_curtailment_time_series(scenario)
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
 
     if resources is None:
         resources = grid.model_immutables.plants["renewable_resources"].intersection(
@@ -85,7 +83,7 @@ def calculate_curtailment_time_series_by_areas(scenario, areas=None):
         (datetime, plant id).
     """
     curtailment = calculate_curtailment_time_series(scenario)
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
 
     areas = (
         _check_areas_are_in_grid_and_format(areas, grid)
@@ -111,13 +109,11 @@ def calculate_curtailment_percentage_by_resources(scenario, resources=None):
     """
     curtailment = calculate_curtailment_time_series_by_resources(scenario, resources)
     resources = set(curtailment.keys())
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
 
     total_curtailment = {r: curtailment[r].sum().sum() for r in resources}
 
-    profiles = pd.concat(
-        [scenario.state.get_solar(), scenario.state.get_wind()], axis=1
-    )
+    profiles = pd.concat([scenario.get_solar(), scenario.get_wind()], axis=1)
     total_potential = profiles.groupby(grid.plant.type, axis=1).sum().sum()
 
     curtailment_percentage = (
@@ -144,7 +140,7 @@ def calculate_curtailment_time_series_by_areas_and_resources(
         resources and values are data frames indexed by (datetime, plant id).
     """
     curtailment = calculate_curtailment_time_series(scenario)
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
 
     areas = (
         _check_areas_are_in_grid_and_format(areas, grid)
@@ -185,7 +181,7 @@ def calculate_curtailment_time_series_by_resources_and_areas(
         areas and values are data frames indexed by (timestamp, plant id).
     """
     curtailment = calculate_curtailment_time_series(scenario)
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
 
     areas = (
         _check_areas_are_in_grid_and_format(areas, grid)
@@ -218,7 +214,7 @@ def summarize_curtailment_by_bus(scenario):
         (bus: curtailment vector).
     """
     curtailment = calculate_curtailment_time_series_by_resources(scenario)
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
 
     bus_curtailment = {
         ren_type: summarize_plant_to_bus(curtailment_df, grid).sum().to_dict()
@@ -236,7 +232,7 @@ def summarize_curtailment_by_location(scenario):
         ((lat, lon): curtailment vector).
     """
     curtailment = calculate_curtailment_time_series_by_resources(scenario)
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
 
     location_curtailment = {
         ren_type: summarize_plant_to_location(curtailment_df, grid).sum().to_dict()
@@ -261,9 +257,7 @@ def get_curtailment_time_series(scenario, area, area_type=None):
     curtailment = get_generation_time_series_by_resources(
         scenario, area, renewables, area_type=area_type
     )
-    renewable_profiles = pd.concat(
-        [scenario.state.get_wind(), scenario.state.get_solar()], axis=1
-    )
+    renewable_profiles = pd.concat([scenario.get_wind(), scenario.get_solar()], axis=1)
     for r in renewables:
         if r in curtailment.columns:
             plant_id = get_plant_id_for_resources_in_area(

--- a/postreise/analyze/generation/emissions.py
+++ b/postreise/analyze/generation/emissions.py
@@ -44,8 +44,8 @@ def generate_emissions_stats(scenario, pollutant="carbon", method="simple"):
         err_msg = f"method for {pollutant} must be one of: {allowed_methods[pollutant]}"
         raise ValueError(err_msg)
 
-    pg = scenario.state.get_pg()
-    grid = scenario.state.get_grid()
+    pg = scenario.get_pg()
+    grid = scenario.get_grid()
     emissions = pd.DataFrame(np.zeros_like(pg), index=pg.index, columns=pg.columns)
 
     if method == "simple":

--- a/postreise/analyze/generation/emissions.py
+++ b/postreise/analyze/generation/emissions.py
@@ -52,8 +52,8 @@ def generate_emissions_stats(scenario, pollutant="carbon", method="simple"):
         for fuel, val in emissions_per_mwh[pollutant].items():
             indices = (grid.plant["type"] == fuel).to_numpy()
             emissions.loc[:, indices] = pg.loc[:, indices] * val / 1000
-    elif method in ("decommit", "always-on"):
-        decommit = True if method == "decommit" else False
+    else:
+        decommit = method == "decommit"
 
         costs = calculate_costs(
             pg=pg, gencost=grid.gencost["before"], decommit=decommit
@@ -66,8 +66,6 @@ def generate_emissions_stats(scenario, pollutant="carbon", method="simple"):
                 costs.iloc[:, indices] / grid.plant["GenFuelCost"].values[indices]
             )
             emissions.loc[:, indices] = heat[:, indices] * val * 44 / 12 / 1000
-    else:
-        raise Exception("I should not be able to get here")
 
     return emissions
 

--- a/postreise/analyze/generation/summarize.py
+++ b/postreise/analyze/generation/summarize.py
@@ -26,7 +26,7 @@ def sum_generation_by_type_zone(
     """
     _check_scenario_is_in_analyze_state(scenario)
 
-    pg = scenario.state.get_pg()
+    pg = scenario.get_pg().copy()
     if time_zone:
         pg = change_time_zone(pg, time_zone)
     if time_range:

--- a/postreise/analyze/generation/summarize.py
+++ b/postreise/analyze/generation/summarize.py
@@ -31,7 +31,7 @@ def sum_generation_by_type_zone(
         pg = change_time_zone(pg, time_zone)
     if time_range:
         pg = slice_time_series(pg, time_range[0], time_range[1])
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
     plant = grid.plant
 
     summed_gen_series = pg.sum().groupby([plant.type, plant.zone_id]).sum()
@@ -49,7 +49,7 @@ def sum_generation_by_state(scenario: Scenario) -> pd.DataFrame:
     """
     # Start with energy by type & zone name
     energy_by_type_zoneid = sum_generation_by_type_zone(scenario)
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
     zoneid2zonename = grid.id2zone
     energy_by_type_zonename = energy_by_type_zoneid.rename(zoneid2zonename, axis=1)
     # Build lists to use for groupbys
@@ -161,8 +161,8 @@ def get_generation_time_series_by_resources(scenario, area, resources, area_type
     plant_id = get_plant_id_for_resources_in_area(
         scenario, area, resources, area_type=area_type
     )
-    pg = scenario.state.get_pg()[plant_id]
-    grid = scenario.state.get_grid()
+    pg = scenario.get_pg()[plant_id]
+    grid = scenario.get_grid()
 
     return pg.groupby(grid.plant.loc[plant_id, "type"].values, axis=1).sum()
 
@@ -185,6 +185,6 @@ def get_storage_time_series(scenario, area, area_type=None, storage_e=False):
     storage_id = get_storage_id_in_area(scenario, area, area_type)
 
     if storage_e:
-        return scenario.state.get_storage_e()[storage_id].sum(axis=1)
+        return scenario.get_storage_e()[storage_id].sum(axis=1)
     else:
-        return scenario.state.get_storage_pg()[storage_id].sum(axis=1)
+        return scenario.get_storage_pg()[storage_id].sum(axis=1)

--- a/postreise/analyze/generation/tests/test_costs.py
+++ b/postreise/analyze/generation/tests/test_costs.py
@@ -76,5 +76,14 @@ def test_pass_just_gencost(mock_gencost):
 
 
 def test_pass_too_many_things(mock_gencost, mock_pg, mock_scenario):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         calculate_costs(gencost=mock_gencost, pg=mock_pg, scenario=mock_scenario)
+    assert "Either scenario XOR (pg AND gencost) must be specified" in str(
+        excinfo.value
+    )
+
+
+def test_negative_pg(mock_gencost, mock_pg):
+    with pytest.raises(ValueError) as excinfo:
+        calculate_costs(gencost=mock_gencost, pg=-1 * mock_pg.iloc[:, 2])
+    assert "PG must be non-negative" in str(excinfo.value)

--- a/postreise/analyze/generation/tests/test_summarize.py
+++ b/postreise/analyze/generation/tests/test_summarize.py
@@ -18,15 +18,15 @@ from postreise.analyze.generation.summarize import (
 # plant_id is the index
 mock_plant = {
     "plant_id": ["A", "B", "C", "D"],
-    "zone_id": [1, 1, 2, 2],
+    "zone_id": [201, 202, 203, 204],
     "type": ["solar", "wind", "hydro", "hydro"],
-    "zone_name": ["Washington", "Washington", "Oregon", "Oregon"],
+    "zone_name": ["Washington", "Oregon", "Northern California", "Bay Area"],
 }
 
 # bus_id is the index
 mock_bus = {
     "bus_id": [1, 2, 3, 4],
-    "zone_id": [201, 201, 202, 202],
+    "zone_id": [201, 202, 203, 204],
 }
 
 mock_storage = {
@@ -40,7 +40,8 @@ mock_pg = pd.DataFrame(
         "B": [1, 2, 4, 8],
         "C": [1, 1, 2, 3],
         "D": [1, 3, 5, 7],
-    }
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
 )
 
 mock_storage_pg = pd.DataFrame(
@@ -53,10 +54,10 @@ mock_storage_pg = pd.DataFrame(
 
 grid_attrs = {"plant": mock_plant, "bus": mock_bus, "storage_gen": mock_storage}
 scenario = MockScenario(grid_attrs, pg=mock_pg, storage_pg=mock_storage_pg)
-scenario.state.grid.zone2id = {
-    "Washington": 201,
-    "Oregon": 202,
+scenario.state.grid.id2zone = {
+    k: v for k, v in zip(mock_plant["zone_id"], mock_plant["zone_name"])
 }
+scenario.state.grid.zone2id = {v: k for k, v in scenario.state.grid.id2zone.items()}
 
 
 class TestSumGenerationByTypeZone(unittest.TestCase):
@@ -65,7 +66,13 @@ class TestSumGenerationByTypeZone(unittest.TestCase):
 
     def test_sum_generation(self):
         expected_return = pd.DataFrame(
-            {"type": ["hydro", "solar", "wind"], 1: [0, 10, 15], 2: [23, 0, 0]}
+            {
+                "type": ["hydro", "solar", "wind"],
+                201: [0, 10, 0],
+                202: [0, 0, 15],
+                203: [7, 0, 0],
+                204: [16, 0, 0],
+            }
         )
         expected_return.set_index("type", inplace=True)
         summed_generation = sum_generation_by_type_zone(self.scenario)
@@ -81,18 +88,64 @@ class TestSumGenerationByTypeZone(unittest.TestCase):
         with self.assertRaises(ValueError):
             sum_generation_by_type_zone(test_scenario)
 
+    def test_with_time_change(self):
+        summed_generation = sum_generation_by_type_zone(
+            self.scenario,
+            time_zone="ETC/GMT+6",
+        )
+        expected_return = pd.DataFrame(
+            {
+                "type": ["hydro", "solar", "wind"],
+                201: [0, 10, 0],
+                202: [0, 0, 15],
+                203: [7, 0, 0],
+                204: [16, 0, 0],
+            }
+        )
+        expected_return.set_index("type", inplace=True)
+        check_dataframe_matches(summed_generation, expected_return)
+
+    def test_with_time_slice(self):
+        summed_generation = sum_generation_by_type_zone(
+            self.scenario,
+            time_range=[pd.Timestamp(2016, 1, 1, 1), pd.Timestamp(2016, 1, 1, 2)],
+        )
+        expected_return = pd.DataFrame(
+            {
+                "type": ["hydro", "solar", "wind"],
+                201: [0, 5, 0],
+                202: [0, 0, 6],
+                203: [3, 0, 0],
+                204: [8, 0, 0],
+            }
+        )
+        expected_return.set_index("type", inplace=True)
+        check_dataframe_matches(summed_generation, expected_return)
+
+    def test_with_time_change_and_time_slice(self):
+        summed_generation = sum_generation_by_type_zone(
+            self.scenario,
+            time_zone="ETC/GMT+1",
+            time_range=[
+                pd.Timestamp("2016-01-01-00", tz="ETC/GMT+1"),
+                pd.Timestamp("2016-01-01-02", tz="ETC/GMT+1"),
+            ],
+        )
+        expected_return = pd.DataFrame(
+            {
+                "type": ["hydro", "solar", "wind"],
+                201: [0, 9, 0],
+                202: [0, 0, 14],
+                203: [6, 0, 0],
+                204: [15, 0, 0],
+            }
+        )
+        expected_return.set_index("type", inplace=True)
+        check_dataframe_matches(summed_generation, expected_return)
+
 
 @pytest.fixture
 def sim_gen_result():
-    scenario = MockScenario(grid_attrs, pg=mock_pg)
-    scenario.state.grid.interconnect = ["Western"]
-    scenario.state.grid.plant.zone_id = [201, 202, 203, 204]
-    scenario.state.grid.id2zone = {
-        201: "Washington",
-        202: "Oregon",
-        203: "Northern California",
-        204: "Bay Area",
-    }
     return sum_generation_by_state(scenario)
 
 
@@ -149,17 +202,17 @@ def test_summarize_hist_gen_shape(hist_gen_raw):
 
 
 def test_get_generation_time_series_by_resources():
-    arg = [(scenario, "Washington", "wind"), (scenario, "Oregon", "hydro")]
+    arg = [(scenario, "Washington", "solar"), (scenario, "Oregon", "wind")]
     expected = [
-        pd.DataFrame({"wind": mock_pg["B"]}),
-        pd.DataFrame({"hydro": mock_pg[["C", "D"]].sum(axis=1)}),
+        pd.DataFrame({"solar": mock_pg["A"]}),
+        pd.DataFrame({"wind": mock_pg[["B"]].sum(axis=1)}),
     ]
     for a, e in zip(arg, expected):
         check_dataframe_matches(get_generation_time_series_by_resources(*a), e)
 
 
 def test_get_storage_time_series():
-    arg = [(scenario, "Oregon"), (scenario, "all")]
-    expected = [mock_storage_pg[2], mock_storage_pg.sum(axis=1)]
+    arg = [(scenario, "Washington"), (scenario, "all")]
+    expected = [mock_storage_pg[0], mock_storage_pg.sum(axis=1)]
     for a, e in zip(arg, expected):
         assert_array_almost_equal(get_storage_time_series(*a), e)

--- a/postreise/analyze/transmission/congestion.py
+++ b/postreise/analyze/transmission/congestion.py
@@ -12,9 +12,9 @@ def calculate_congestion_surplus(scenario):
     """
     _check_scenario_is_in_analyze_state(scenario)
 
-    grid = scenario.state.get_grid()
-    lmp = scenario.state.get_lmp()
-    pg = scenario.state.get_pg()
+    grid = scenario.get_grid()
+    lmp = scenario.get_lmp()
+    pg = scenario.get_pg()
 
     bus_demand = scenario.get_bus_demand()
     bus_pg = summarize_plant_to_bus(pg, grid, all_buses=True)

--- a/postreise/analyze/transmission/congestion.py
+++ b/postreise/analyze/transmission/congestion.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pandas as pd
 from powersimdata.input.helpers import summarize_plant_to_bus
-from powersimdata.scenario.analyze import Analyze
-from powersimdata.scenario.scenario import Scenario
+from powersimdata.scenario.check import _check_scenario_is_in_analyze_state
 
 
 def calculate_congestion_surplus(scenario):
@@ -11,11 +10,7 @@ def calculate_congestion_surplus(scenario):
     :param powersimdata.scenario.scenario.Scenario scenario: scenario instance.
     :return: (*pandas.DataFrame*) -- congestion surplus.
     """
-
-    if not isinstance(scenario, Scenario):
-        raise TypeError("scenario must be a Scenario object")
-    if not isinstance(scenario.state, Analyze):
-        raise ValueError("scenario.state must be Analyze")
+    _check_scenario_is_in_analyze_state(scenario)
 
     grid = scenario.state.get_grid()
     lmp = scenario.state.get_lmp()

--- a/postreise/analyze/transmission/tests/test_utilization.py
+++ b/postreise/analyze/transmission/tests/test_utilization.py
@@ -1,0 +1,81 @@
+import pandas as pd
+from pandas.testing import assert_frame_equal
+from powersimdata.input.tests.test_helpers import check_dataframe_matches
+from powersimdata.tests.mock_grid import MockGrid
+
+from postreise.analyze.transmission.utilization import (
+    _count_hours_gt_threshold,
+    generate_cong_stats,
+    get_utilization,
+)
+
+mock_branch = {
+    "branch_id": [101, 102],
+    "branch_device_type": ["Line"] * 2,
+    "rateA": [20, 10],
+    "from_lat": [47, 47],
+    "from_lon": [122, 122],
+    "to_lat": [47.12, 46.33],
+    "to_lon": [122.23, 121.11],
+}
+
+mock_grid = MockGrid(grid_attrs={"branch": mock_branch})
+
+mock_pf = pd.DataFrame(
+    {
+        101: [12, -8, -18, 2],
+        102: [1, 8, 9, 6],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+
+def test_get_utilization():
+    expected = pd.DataFrame(
+        {101: [0.6, 0.4, 0.9, 0.1], 102: [0.1, 0.8, 0.9, 0.6]}, index=mock_pf.index
+    )
+    check_dataframe_matches(expected, get_utilization(mock_grid.branch, mock_pf))
+
+
+def test_get_utilization_median():
+    expected = pd.DataFrame({101: [0.5], 102: [0.7]})
+    check_dataframe_matches(
+        expected,
+        get_utilization(mock_grid.branch, mock_pf, median=True),
+    )
+
+
+def test_count_hours_gt_threshold():
+    threshold = 0.25
+    expected = pd.Series(data=[3, 3], index=[101, 102])
+
+    utilization = get_utilization(mock_grid.branch, mock_pf)
+    assert _count_hours_gt_threshold(utilization, threshold).equals(expected)
+
+
+def test_generate_cong_stats():
+    util = [0.5, 0.75, 0.85]
+    threshold = [0.5, 0.25, 0.05]
+    n = len(mock_pf)
+
+    expected = pd.DataFrame(
+        {
+            "capacity": [20.0, 10.0],
+            "branch_device_type": ["Line"] * 2,
+            "per_util1": [2 / n, 3 / n],
+            "per_util2": [1 / n, 2 / n],
+            "per_util3": [1 / n, 1 / n],
+            "bind": [0, 0],
+            "risk": [-18.0, 17.0],
+            "uflag1": [1, 1],
+            "uflag2": [1, 1],
+            "uflag3": [1, 1],
+            "sumflag": [3, 3],
+        },
+        index=[101, 102],
+    )
+    expected.index.name = "branch_id"
+    statistics = generate_cong_stats(
+        mock_pf, mock_grid.branch, util=util, threshold=threshold
+    )
+    assert_frame_equal(expected, statistics.drop("dist", axis=1))

--- a/postreise/plot/plot_bar_generation_max_min_actual.py
+++ b/postreise/plot/plot_bar_generation_max_min_actual.py
@@ -33,7 +33,7 @@ def plot_bar_generation_max_min_actual(
     :param plot_show: show the plot or not, defaults to True.
     :return: (*matplotlib.axes.Axes*) -- axes object of the plot.
     """
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
     plant = grid.plant[grid.plant.type == gen_type]
     mi = ModelImmutables(scenario.info["grid_model"])
     hour_num = (

--- a/postreise/plot/plot_bar_generation_stack.py
+++ b/postreise/plot/plot_bar_generation_stack.py
@@ -112,7 +112,12 @@ def plot_bar_generation_stack(
     all_loadzone_data = dict()
     for sid, scenario in zip(scenario_ids, s_list):
         curtailment = calculate_curtailment_time_series_by_areas_and_resources(
-            scenario, areas={"loadzone": mi.zones["loadzone"]}
+            scenario,
+            areas={
+                "loadzone": mi.zones["interconnect2loadzone"][
+                    scenario.info["interconnect"]
+                ]
+            },
         )
         for area in curtailment:
             for r in curtailment[area]:
@@ -196,7 +201,7 @@ def plot_bar_generation_stack(
         if scenario_names:
             labels = scenario_names
         else:
-            labels = [s.info["name'"] for s in s_list]
+            labels = [s.info["name"] for s in s_list]
         ax.set_xticks([i * x_scale for i in range(len(s_list))])
         ax.set_xticklabels(labels, fontsize=12)
         ax.set_ylabel("TWh", fontsize=12)

--- a/postreise/plot/plot_bar_generation_stack.py
+++ b/postreise/plot/plot_bar_generation_stack.py
@@ -61,12 +61,12 @@ def plot_bar_generation_stack(
         directory if None.
     :return: (*list*) -- matplotlib.axes.Axes object of each plot in a list.
     :raises TypeError:
-        if resources is not a list/str and/or
-        if titles is provided but not in a dictionary format and/or
-        if filenames is provided but not in a dictionary format.
+        if ``resources`` is not a list or str.
+        if ``titles`` is not a dict.
+        if ``filenames`` is not a dict.
     :raises ValueError:
-        if length of area_types and areas is different and/or
-        if length of scenario_names and scenario_ids is different.
+        if length of ``area_types`` and ``areas`` is different.
+        if length of ``scenario_names`` and ``scenario_ids`` is different.
     """
     if isinstance(areas, str):
         areas = [areas]

--- a/postreise/plot/plot_bar_generation_stack.py
+++ b/postreise/plot/plot_bar_generation_stack.py
@@ -127,7 +127,7 @@ def plot_bar_generation_stack(
         all_loadzone_data[sid] = pd.concat(
             [
                 sum_generation_by_type_zone(scenario).T,
-                scenario.state.get_demand().sum().T.rename("load"),
+                scenario.get_demand().sum().T.rename("load"),
                 curtailment,
             ],
             axis=1,

--- a/postreise/plot/plot_bar_generation_stack.py
+++ b/postreise/plot/plot_bar_generation_stack.py
@@ -73,29 +73,25 @@ def plot_bar_generation_stack(
     if isinstance(scenario_ids, (int, str)):
         scenario_ids = [scenario_ids]
     if not isinstance(scenario_ids, list):
-        raise TypeError("ERROR: scenario_ids should be a int/str/list")
+        raise TypeError("scenario_ids must be a int, str or list")
     if isinstance(resources, str):
         resources = [resources]
     if not isinstance(resources, list):
-        raise TypeError("ERROR: resources should be a list/str")
+        raise TypeError("resources must be a list or str")
     if isinstance(area_types, str):
         area_types = [area_types]
     if not area_types:
         area_types = [None] * len(areas)
     if len(areas) != len(area_types):
-        raise ValueError(
-            "ERROR: if area_types are provided, number of area_types must match number of areas"
-        )
+        raise ValueError("area_types must have same size as areas")
     if isinstance(scenario_names, str):
         scenario_names = [scenario_names]
     if scenario_names and len(scenario_names) != len(scenario_ids):
-        raise ValueError(
-            "ERROR: if scenario names are provided, number of scenario names must match number of scenario ids"
-        )
+        raise ValueError("scenario_names must have same size as scenario_ids")
     if titles is not None and not isinstance(titles, dict):
-        raise TypeError("ERROR: titles should be a dictionary if provided")
+        raise TypeError("titles must be a dictionary")
     if filenames is not None and not isinstance(filenames, dict):
-        raise TypeError("ERROR: filenames should be a dictionary if provided")
+        raise TypeError("filenames must be a dictionary")
     s_list = []
     for sid in scenario_ids:
         s_list.append(Scenario(sid))

--- a/postreise/plot/plot_bar_generation_vs_capacity.py
+++ b/postreise/plot/plot_bar_generation_vs_capacity.py
@@ -18,6 +18,7 @@ def plot_bar_generation_vs_capacity(
     resource_types=None,
     resource_labels=None,
     horizontal=False,
+    plot_show=True,
 ):
     """Plot any number of scenarios as bar or horizontal bar charts with two columns per
     scenario - generation and capacity.
@@ -42,6 +43,7 @@ def plot_bar_generation_vs_capacity(
         being labels to show in the plots, defaults to None, which uses
         resource_types as labels.
     :param bool horizontal: display bars horizontally, default to False.
+    :return: (*matplotlib.axes.Axes*) -- axes object of the plot.
     """
     if isinstance(areas, str):
         areas = [areas]
@@ -152,9 +154,14 @@ def plot_bar_generation_vs_capacity(
             )
 
         if horizontal:
-            _construct_hbar_visuals(area, ax_data_list)
+            axes = _construct_hbar_visuals(area, ax_data_list)
         else:
-            _construct_bar_visuals(area, ax_data_list)
+            axes = _construct_bar_visuals(area, ax_data_list)
+
+        if plot_show:
+            plt.show()
+        else:
+            return axes
 
 
 def _construct_bar_visuals(zone, ax_data_list):
@@ -201,7 +208,7 @@ def _construct_bar_visuals(zone, ax_data_list):
             )
 
     axes[1].get_legend().remove()
-    plt.show()
+    return axes
 
 
 def _construct_hbar_visuals(zone, ax_data_list):
@@ -249,7 +256,7 @@ def _construct_hbar_visuals(zone, ax_data_list):
                 fontsize=14,
                 verticalalignment="top",
             )
-    plt.show()
+    return axes
 
 
 def _get_bar_display_val(val):

--- a/postreise/plot/plot_bar_generation_vs_capacity.py
+++ b/postreise/plot/plot_bar_generation_vs_capacity.py
@@ -52,9 +52,7 @@ def plot_bar_generation_vs_capacity(
     if not area_types:
         area_types = [None] * len(areas)
     if len(areas) != len(area_types):
-        raise ValueError(
-            "ERROR: if area_types are provided, it should have the same number of entries with areas."
-        )
+        raise ValueError("area_types must have same size as areas")
 
     if not scenario_ids:
         scenario_ids = []
@@ -63,21 +61,17 @@ def plot_bar_generation_vs_capacity(
     if isinstance(scenario_names, str):
         scenario_names = [scenario_names]
     if scenario_names and len(scenario_names) != len(scenario_ids):
-        raise ValueError(
-            "ERROR: if scenario names are provided, number of scenario names must match number of scenario ids"
-        )
+        raise ValueError("scenario_names must have same size as scenario_ids")
     if not custom_data:
         custom_data = {}
     if len(scenario_ids) + len(custom_data) <= 1:
-        raise ValueError(
-            "ERROR: must include at least two scenario ids and/or custom data"
-        )
+        raise ValueError("two scenario and/or custom data must be provided")
     if isinstance(resource_types, str):
         resource_types = [resource_types]
     if not resource_labels:
         resource_labels = dict()
     if not isinstance(resource_labels, dict):
-        raise TypeError("ERROR: resource_labels should be a dictionary")
+        raise TypeError("resource_labels must be a dict")
 
     all_loadzone_data = {}
     scenario_data = {}

--- a/postreise/plot/plot_bar_generation_vs_capacity.py
+++ b/postreise/plot/plot_bar_generation_vs_capacity.py
@@ -44,6 +44,12 @@ def plot_bar_generation_vs_capacity(
         resource_types as labels.
     :param bool horizontal: display bars horizontally, default to False.
     :return: (*matplotlib.axes.Axes*) -- axes object of the plot.
+    :raises TypeError:
+        if ``resource_labels`` is not a dict.
+    :raises ValueError:
+        if length of ``area_types`` and ``areas`` is different.
+        if length of ``scenario_names`` and ``scenario_ids`` is different.
+        if only one scenario is provided with no ``custom_data``.
     """
     if isinstance(areas, str):
         areas = [areas]

--- a/postreise/plot/plot_bar_renewable_max_profile_actual.py
+++ b/postreise/plot/plot_bar_renewable_max_profile_actual.py
@@ -36,12 +36,12 @@ def plot_bar_renewable_max_profile_actual(
     mi = ModelImmutables(scenario.info["grid_model"])
     if gen_type not in mi.plants["renewable_resources"]:
         raise ValueError("gen_type must be one of renewable resources")
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
     plant = grid.plant[grid.plant.type == gen_type]
     if "wind" in gen_type:
-        profile = scenario.state.get_wind().sum()
+        profile = scenario.get_wind().sum()
     else:
-        profile = scenario.state.get_solar().sum()
+        profile = scenario.get_solar().sum()
     hour_num = (
         pd.Timestamp(scenario.info["end_date"])
         - pd.Timestamp(scenario.info["start_date"])

--- a/postreise/plot/plot_bar_renewable_max_profile_actual.py
+++ b/postreise/plot/plot_bar_renewable_max_profile_actual.py
@@ -1,6 +1,11 @@
 import matplotlib.pyplot as plt
 import pandas as pd
+from powersimdata.input.check import (
+    _check_resources_are_in_grid_and_format,
+    _check_resources_are_renewable_and_format,
+)
 from powersimdata.network.model import ModelImmutables
+from powersimdata.scenario.check import _check_scenario_is_in_analyze_state
 
 from postreise.analyze.generation.summarize import (
     sum_generation_by_state,
@@ -31,13 +36,40 @@ def plot_bar_renewable_max_profile_actual(
     :param int/float fontsize: font size of the texts shown on the plot.
     :param plot_show: show the plot or not, defaults to True.
     :return: (*matplotlib.axes.Axes*) -- axes object of the plot.
-    :raises ValueError: if gen_type is not one of renewable resources.
+    :raises TypeError:
+        if ``interconnect`` and ``gen_type`` are not str
+        if ``fontsize`` is not a int or a float
+    :raises ValueError: if ``interconnect is not valid
     """
-    mi = ModelImmutables(scenario.info["grid_model"])
-    if gen_type not in mi.plants["renewable_resources"]:
-        raise ValueError("gen_type must be one of renewable resources")
+    _check_scenario_is_in_analyze_state(scenario)
+    if not isinstance(interconnect, str):
+        raise TypeError("interconnect must be a str")
+    if not isinstance(gen_type, str):
+        raise TypeError("gen_type must be a str")
+    if not isinstance(fontsize, (int, float)):
+        raise TypeError("fontsize must be either a int or a float")
+
     grid = scenario.get_grid()
+    _check_resources_are_in_grid_and_format(gen_type, grid)
+    _check_resources_are_renewable_and_format(
+        gen_type, grid_model=scenario.info["grid_model"]
+    )
+
     plant = grid.plant[grid.plant.type == gen_type]
+    mi = ModelImmutables(scenario.info["grid_model"])
+    if interconnect not in mi.zones["interconnect"]:
+        raise ValueError(
+            f"interconnect must be one of {sorted(mi.zones['interconnect'])}"
+        )
+    if (
+        len(
+            mi.zones["interconnect2abv"][interconnect]
+            - mi.zones["interconnect2abv"][scenario.info["interconnect"]]
+        )
+        != 0
+    ):
+        raise ValueError("interconnect is incompatible with scenario's interconnect")
+
     if "wind" in gen_type:
         profile = scenario.get_wind().sum()
     else:

--- a/postreise/plot/plot_bar_shortfall.py
+++ b/postreise/plot/plot_bar_shortfall.py
@@ -49,23 +49,21 @@ def plot_bar_shortfall(
     if isinstance(scenario_ids, (int, str)):
         scenario_ids = [scenario_ids]
     if not isinstance(target_df, pd.DataFrame):
-        raise TypeError("ERROR: target_df must be a pandas.DataFrame")
+        raise TypeError("target_df must be a pandas.DataFrame")
     if strategy is None:
         strategy = dict()
     if not isinstance(strategy, dict):
-        raise TypeError("ERROR: strategy must be a dictionary")
+        raise TypeError("strategy must be a dict")
     if isinstance(scenario_names, str):
         scenario_names = [scenario_names]
     if scenario_names is not None and len(scenario_names) != len(scenario_ids):
-        raise ValueError(
-            "ERROR: if scenario names are provided, number of scenario names must match number of scenario ids"
-        )
+        raise ValueError("scenario_names must have same size as scenario_ids")
     if baseline_scenario is not None and not isinstance(baseline_scenario, (str, int)):
-        raise TypeError("ERROR: baseline_scenario must be a string or integer")
+        raise TypeError("baseline_scenario must be a str or int")
     if baseline_scenario_name is not None and not isinstance(
         baseline_scenario_name, str
     ):
-        raise TypeError("ERROR: baseline_scenario_name must be a string")
+        raise TypeError("baseline_scenario_name must be a str")
 
     scenarios = dict()
     targets = dict()

--- a/postreise/plot/plot_bar_shortfall.py
+++ b/postreise/plot/plot_bar_shortfall.py
@@ -1,3 +1,4 @@
+import matplotlib.pyplot as plt
 import pandas as pd
 from powersimdata.design.generation.clean_capacity_scaling import (
     add_demand_to_targets,
@@ -16,6 +17,7 @@ def plot_bar_shortfall(
     scenario_names=None,
     baseline_scenario=None,
     baseline_scenario_name=None,
+    plot_show=True,
 ):
     """Plot a stacked bar chart of generation shortfall based on given targets for
         any number of scenarios.
@@ -36,6 +38,8 @@ def plot_bar_shortfall(
     :param str baseline_scenario_name: specify the label of the baseline scenario
         shown in the bar chart, default to None, in which case the name of the
         scenario will be used.
+    :param bool plot_show: display the generated figure or not, defaults to True.
+    :return: (*matplotlib.axes.Axes*) -- axes object of the plot.
     :raises ValueError:
         if length of scenario_names and scenario_ids is different.
     :raises TypeError:
@@ -147,7 +151,7 @@ def plot_bar_shortfall(
             target_pct = round(100 * target_generation / target_demand, 2)
 
         if baseline_scenario:
-            _construct_shortfall_visuals(
+            axes = _construct_shortfall_visuals(
                 area,
                 ax_data,
                 target_pct,
@@ -155,11 +159,15 @@ def plot_bar_shortfall(
                 baseline_scenario_name=baseline_scenario_name,
             )
         else:
-            _construct_shortfall_visuals(
+            axes = _construct_shortfall_visuals(
                 area,
                 ax_data,
                 target_pct,
             )
+        if plot_show:
+            plt.show()
+        else:
+            return axes
 
 
 def _construct_shortfall_visuals(

--- a/postreise/plot/plot_carbon_bar.py
+++ b/postreise/plot/plot_carbon_bar.py
@@ -36,7 +36,7 @@ def plot_carbon_bar(*args, labels=None, labels_size=15, show_plot=True):
 
     carbon_val = {"coal": [], "ng": []}
     for i, s in enumerate(args):
-        grid = s.state.get_grid()
+        grid = s.get_grid()
         carbon_by_bus = summarize_emissions_by_bus(generate_emissions_stats(s), grid)
         carbon_val["coal"].append(sum(carbon_by_bus["coal"].values()))
         carbon_val["ng"].append(sum(carbon_by_bus["ng"].values()))
@@ -70,10 +70,10 @@ def carbon_diff(scenario_1, scenario_2):
     :return: (*float*) -- relative difference in emission in percent.
     """
     carbon_by_bus_1 = summarize_emissions_by_bus(
-        generate_emissions_stats(scenario_1), scenario_1.state.get_grid()
+        generate_emissions_stats(scenario_1), scenario_1.get_grid()
     )
     carbon_by_bus_2 = summarize_emissions_by_bus(
-        generate_emissions_stats(scenario_2), scenario_2.state.get_grid()
+        generate_emissions_stats(scenario_2), scenario_2.get_grid()
     )
 
     sum_1 = sum(carbon_by_bus_1["coal"].values()) + sum(carbon_by_bus_1["ng"].values())

--- a/postreise/plot/plot_carbon_map.py
+++ b/postreise/plot/plot_carbon_map.py
@@ -20,7 +20,7 @@ def combine_bus_info_and_emission(scenario):
     :param powersimdata.scenario.scenario.Scenario scenario: scenario instance.
     :return: (*pandas.DataFrame*) -- bus data frame with emission.
     """
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
     carbon_by_bus = summarize_emissions_by_bus(generate_emissions_stats(scenario), grid)
 
     selected = grid.bus.loc[pd.DataFrame.from_dict(carbon_by_bus).index]

--- a/postreise/plot/plot_energy_carbon_stack.py
+++ b/postreise/plot/plot_energy_carbon_stack.py
@@ -27,14 +27,14 @@ def plot_n_scenarios(*args):
     scenario_numbers = [a.info["id"] for a in args]
     first_id = scenario_numbers[0]
     scenarios = {id: scen for (id, scen) in zip(scenario_numbers, args)}
-    grid = {id: scenario.state.get_grid() for id, scenario in scenarios.items()}
+    grid = {id: scenario.get_grid() for id, scenario in scenarios.items()}
     plant = {k: v.plant for k, v in grid.items()}
     # First scenario is chosen to set fuel colors
     type2color = ModelImmutables(args[0].info["grid_model"]).plants["type2color"]
     carbon_by_type, energy_by_type = {}, {}
     for id, scenario in scenarios.items():
         # Calculate raw numbers
-        annual_plant_energy = scenario.state.get_pg().sum()
+        annual_plant_energy = scenario.get_pg().sum()
         raw_energy_by_type = annual_plant_energy.groupby(plant[id].type).sum()
         annual_plant_carbon = generate_emissions_stats(scenario).sum()
         raw_carbon_by_type = annual_plant_carbon.groupby(plant[id].type).sum()

--- a/postreise/plot/plot_lmp_map.py
+++ b/postreise/plot/plot_lmp_map.py
@@ -67,8 +67,8 @@ def map_lmp(
     if scale_factor < 0:
         raise ValueError("scale_factor must be positive")
 
-    grid = scenario.state.get_grid()
-    lmp = scenario.state.get_lmp()
+    grid = scenario.get_grid()
+    lmp = scenario.get_lmp()
     bus_with_lmp = grid.bus.copy()
     bus_with_lmp["lmp"] = lmp.mean()
 

--- a/postreise/plot/plot_powerflow_snapshot.py
+++ b/postreise/plot/plot_powerflow_snapshot.py
@@ -136,12 +136,12 @@ def plot_powerflow_snapshot(
     _check_scenario_is_in_analyze_state(scenario)
     _check_date_range_in_scenario(scenario, hour, hour)
     # Get scenario data
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
     bus = grid.bus
     plant = grid.plant
     # Augment the branch dataframe with extra info needed for plotting
     branch = grid.branch
-    branch["pf"] = scenario.state.get_pf().loc[hour]
+    branch["pf"] = scenario.get_pf().loc[hour]
     branch = branch.query("pf != 0").copy()
     branch["dist"] = branch.apply(
         lambda x: haversine((x.from_lat, x.from_lon), (x.to_lat, x.to_lon)), axis=1
@@ -150,7 +150,7 @@ def plot_powerflow_snapshot(
     branch = project_branch(branch)
     # Augment the dcline dataframe with extra info needed for plotting
     dcline = grid.dcline
-    dcline["pf"] = scenario.state.get_dcline_pf().loc[hour]
+    dcline["pf"] = scenario.get_dcline_pf().loc[hour]
     dcline["from_lat"] = dcline.apply(lambda x: bus.loc[x.from_bus_id, "lat"], axis=1)
     dcline["from_lon"] = dcline.apply(lambda x: bus.loc[x.from_bus_id, "lon"], axis=1)
     dcline["to_lat"] = dcline.apply(lambda x: bus.loc[x.to_bus_id, "lat"], axis=1)
@@ -162,7 +162,7 @@ def plot_powerflow_snapshot(
     dcline = project_branch(dcline)
     # Create a dataframe for demand plotting, if necessary
     if demand_centers is not None:
-        demand = scenario.state.get_demand()
+        demand = scenario.get_demand()
         demand_centers["demand"] = demand.loc[hour]
         demand_centers = project_bus(demand_centers)
 
@@ -281,7 +281,7 @@ def plot_powerflow_snapshot(
 
     # Aggregate solar and wind for plotting
     plant_with_pg = plant.copy()
-    plant_with_pg["pg"] = scenario.state.get_pg().loc[hour]
+    plant_with_pg["pg"] = scenario.get_pg().loc[hour]
     grouped_solar = aggregate_plant_generation(plant_with_pg.query("type == 'solar'"))
     grouped_wind = aggregate_plant_generation(plant_with_pg.query("type == 'wind'"))
     # Plot solar, wind

--- a/postreise/plot/plot_scatter_capacity_vs_capacity_factor.py
+++ b/postreise/plot/plot_scatter_capacity_vs_capacity_factor.py
@@ -83,7 +83,7 @@ def plot_scatter_capacity_vs_capacity_factor(
     plant_id = get_plant_id_for_resources_in_area(
         scenario, area, resources, area_type=area_type
     )
-    plant_df = scenario.state.get_grid().plant.loc[plant_id]
+    plant_df = scenario.get_grid().plant.loc[plant_id]
     if total_cap == 0:
         data_avg = 0
     else:

--- a/postreise/plot/plot_scatter_capacity_vs_cost_curve_slope.py
+++ b/postreise/plot/plot_scatter_capacity_vs_cost_curve_slope.py
@@ -44,7 +44,7 @@ def plot_scatter_capacity_vs_cost_curve_slope(
     plant_id = get_plant_id_for_resources_in_area(
         scenario, area, resources, area_type=area_type
     )
-    grid = scenario.state.get_grid()
+    grid = scenario.get_grid()
     plant_df = grid.plant.loc[plant_id]
     cost_df = grid.gencost["after"].loc[plant_id]
     slope = (cost_df["f2"] - cost_df["f1"]) / (cost_df["p2"] - cost_df["p1"])

--- a/postreise/plot/plot_scatter_capacity_vs_curtailment.py
+++ b/postreise/plot/plot_scatter_capacity_vs_curtailment.py
@@ -84,16 +84,14 @@ def plot_scatter_capacity_vs_curtailment(
         between_time=between_time,
         dayofweek=dayofweek,
     )
-    profiles = pd.concat(
-        [scenario.state.get_solar(), scenario.state.get_wind()], axis=1
-    )
+    profiles = pd.concat([scenario.get_solar(), scenario.get_wind()], axis=1)
     curtailment = curtailment.sum() / profiles[curtailment.columns].sum()
     if percentage:
         curtailment = (curtailment * 100).round(2)
     total_cap = get_capacity_by_resources(
         scenario, area, resources, area_type=area_type
     ).sum()
-    plant_df = scenario.state.get_grid().plant.loc[plant_list]
+    plant_df = scenario.get_grid().plant.loc[plant_list]
     if total_cap == 0:
         data_avg = 0
     else:

--- a/postreise/plot/plot_shadowprice_map.py
+++ b/postreise/plot/plot_shadowprice_map.py
@@ -59,7 +59,7 @@ def _get_shadowprice_data(scenario_id):
     interconnect = s.info["interconnect"]
     interconnect = " ".join(interconnect.split("_"))
 
-    s_grid = s.state.get_grid()
+    s_grid = s.get_grid()
 
     # Get bus and add location data
     bus_map = project_bus(s_grid.bus)
@@ -68,15 +68,15 @@ def _get_shadowprice_data(scenario_id):
     branch_map = project_branch(s_grid.branch)
 
     # get congestion
-    congu = s.state.get_congu()
-    congl = s.state.get_congl()
+    congu = s.get_congu()
+    congl = s.get_congl()
     cong_abs = pd.DataFrame(
         np.maximum(congu.to_numpy(), congl.to_numpy()),
         columns=congu.columns,
         index=congu.index,
     )
 
-    return interconnect, bus_map, s.state.get_lmp(), branch_map, cong_abs
+    return interconnect, bus_map, s.get_lmp(), branch_map, cong_abs
 
 
 def _construct_bus_data(bus_map, lmp, user_set_split_points, datetime):

--- a/postreise/plot/plot_tornado.py
+++ b/postreise/plot/plot_tornado.py
@@ -3,8 +3,7 @@ import pandas as pd
 
 
 def plot_tornado(title, data, sorted=False):
-    """
-    Plots a tornado graph (horizontal bar with both positive and neg values)
+    """Plots a tornado graph (horizontal bar with both positive and neg values)
 
     :param str title: Title of the plot
     :param dict data: dictionary of data to be plotted

--- a/postreise/plot/plot_transmission_upgrades_map.py
+++ b/postreise/plot/plot_transmission_upgrades_map.py
@@ -280,8 +280,8 @@ def map_transmission_upgrades(
         raise ValueError("Scenarios to compare must be same grid model & interconnect")
 
     # Pre-plot data processing
-    grid1 = scenario1.state.get_grid()
-    grid2 = scenario2.state.get_grid()
+    grid1 = scenario1.get_grid()
+    grid2 = scenario2.get_grid()
     branch_merge = calculate_branch_difference(grid1.branch, grid2.branch)
     dc_merge = calculate_dcline_difference(grid1, grid2)
 

--- a/postreise/plot/plot_utilization_map.py
+++ b/postreise/plot/plot_utilization_map.py
@@ -74,8 +74,8 @@ def map_risk_bind(
     # Check that we've appropriately specified:
     #    `scenario` XOR (`congestion_stats` AND `branch`)
     if scenario is not None:
-        branch = scenario.state.get_grid().branch
-        congestion_stats = generate_cong_stats(scenario.state.get_pf(), branch)
+        branch = scenario.get_grid().branch
+        congestion_stats = generate_cong_stats(scenario.get_pf(), branch)
     elif congestion_stats is not None and branch is not None:
         pass
     else:
@@ -207,8 +207,8 @@ def map_utilization(
     # Check that we've appropriately specified:
     #    `scenario` XOR (`utilization_df` AND `branch`)
     if scenario is not None:
-        branch = scenario.state.get_grid().branch
-        utilization_df = get_utilization(branch, scenario.state.get_pf(), median=True)
+        branch = scenario.get_grid().branch
+        utilization_df = get_utilization(branch, scenario.get_pf(), median=True)
     elif utilization_df is not None and branch is not None:
         pass
     else:

--- a/postreise/plot/tests/test_canvas.py
+++ b/postreise/plot/tests/test_canvas.py
@@ -1,0 +1,43 @@
+import bokeh.plotting as plt
+import pytest
+
+from postreise.plot.canvas import create_map_canvas
+
+
+def test_create_map_canvas_argument_type():
+    with pytest.raises(TypeError) as excinfo:
+        create_map_canvas(figsize=[1400, 800])
+    assert "figsize must be a tuple" in str(excinfo.value)
+
+
+def test_create_map_canvas_argument_size():
+    with pytest.raises(ValueError) as excinfo:
+        create_map_canvas(x_range=(1, 2, 3))
+    assert "x_range must have two elements" in str(excinfo.value)
+
+
+def test_create_map_canvas_figsize():
+    with pytest.raises(TypeError) as excinfo:
+        create_map_canvas(figsize=(1400.1, 800))
+    assert "all elements of figsize must be int" in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        create_map_canvas(figsize=(1400, -800))
+    assert "all elements of figsize must be positive" in str(excinfo.value)
+
+
+def test_create_map_canvas_range():
+    with pytest.raises(TypeError) as excinfo:
+        create_map_canvas(y_range=(-1, "1"))
+    assert "all elements of y_range must be int or float" in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        create_map_canvas(y_range=(100, -100))
+    assert "y_range: 1st element must be lower than 2nd" in str(excinfo.value)
+
+
+def test_create_map_canvas():
+    canvas = create_map_canvas(
+        figsize=(1200, 600), x_range=(-100, 100), y_range=(-10, 10)
+    )
+    assert isinstance(canvas, plt.Figure) is True

--- a/postreise/plot/tests/test_plot_bar_generation_max_min_actual.py
+++ b/postreise/plot/tests/test_plot_bar_generation_max_min_actual.py
@@ -1,0 +1,86 @@
+import pandas as pd
+import pytest
+from powersimdata.tests.mock_scenario import MockScenario
+
+from postreise.plot.plot_bar_generation_max_min_actual import (
+    plot_bar_generation_max_min_actual,
+)
+
+mock_plant = {
+    "plant_id": ["A", "B", "C", "D", "E", "F", "G", "H"],
+    "zone_id": [301, 302, 303, 304, 305, 306, 307, 308],
+    "Pmax": [100, 75, 150, 30, 50, 300, 200, 80],
+    "Pmin": [0, 0, 0, 0, 0, 100, 10, 0],
+    "type": ["solar", "wind", "hydro", "hydro", "wind", "coal", "ng", "wind"],
+    "zone_name": [
+        "Far West",
+        "North",
+        "West",
+        "South",
+        "North Central",
+        "South Central",
+        "Coast",
+        "East",
+    ],
+}
+
+mock_pg = pd.DataFrame(
+    {
+        "A": [80, 75, 72, 81],
+        "B": [22, 22, 25, 20],
+        "C": [130, 130, 130, 130],
+        "D": [25, 26, 27, 28],
+        "E": [10, 11, 9, 12],
+        "F": [290, 295, 295, 294],
+        "G": [190, 190, 191, 190],
+        "H": [61, 63, 65, 67],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+grid_attrs = {"plant": mock_plant}
+scenario = MockScenario(grid_attrs, pg=mock_pg)
+scenario.info["interconnect"] = "Texas"
+scenario.info["start_date"] = pd.Timestamp(2016, 1, 1)
+scenario.info["end_date"] = pd.Timestamp(2016, 1, 1, 3)
+scenario.state.grid.id2zone = {
+    k: v for k, v in zip(mock_plant["zone_id"], mock_plant["zone_name"])
+}
+scenario.state.grid.zone2id = {v: k for k, v in scenario.state.grid.id2zone.items()}
+
+
+def test_plot_bar_generation_max_min_actual():
+    plot_bar_generation_max_min_actual(scenario, "Texas", "wind", plot_show=False)
+    plot_bar_generation_max_min_actual(
+        scenario, "Texas", "wind", show_as_state=False, percentage=True, plot_show=False
+    )
+
+
+def test_plot_bar_generation_max_min_actual_argument_type():
+    with pytest.raises(TypeError) as excinfo:
+        plot_bar_generation_max_min_actual(scenario, ["Texas"], "wind", plot_show=False)
+    assert "interconnect must be a str" in str(excinfo.value)
+
+    with pytest.raises(TypeError) as excinfo:
+        plot_bar_generation_max_min_actual(scenario, "Texas", ["coal"], plot_show=False)
+    assert "gen_type must be a str" in str(excinfo.value)
+
+    with pytest.raises(TypeError) as excinfo:
+        plot_bar_generation_max_min_actual(
+            scenario, "Texas", "wind", fontsize="15", plot_show=False
+        )
+    assert "fontsize must be either a int or a float" in str(excinfo.value)
+
+
+def test_plot_bar_generation_max_min_actual_argument_value():
+    with pytest.raises(ValueError) as excinfo:
+        plot_bar_generation_max_min_actual(scenario, "Europe", "wind", plot_show=False)
+    assert (
+        "interconnect must be one of ['Eastern', 'Texas', 'Texas_Western', 'USA', 'Western']"
+        in str(excinfo.value)
+    )
+    with pytest.raises(ValueError) as excinfo:
+        plot_bar_generation_max_min_actual(scenario, "Western", "wind", plot_show=False)
+    assert "interconnect is incompatible with scenario's interconnect" in str(
+        excinfo.value
+    )

--- a/postreise/plot/tests/test_plot_bar_generation_stack.py
+++ b/postreise/plot/tests/test_plot_bar_generation_stack.py
@@ -1,58 +1,146 @@
+from unittest.mock import patch
+
+import pandas as pd
 import pytest
+from powersimdata.tests.mock_scenario import MockScenario
 
 from postreise.plot.plot_bar_generation_stack import plot_bar_generation_stack
 
+mock_plant = {
+    "plant_id": ["A", "B", "C", "D", "E", "F", "G", "H"],
+    "zone_id": [301, 302, 303, 304, 305, 306, 307, 308],
+    "Pmax": [100, 75, 150, 30, 50, 300, 200, 80],
+    "Pmin": [0, 0, 0, 0, 0, 100, 10, 0],
+    "type": ["solar", "wind", "solar", "wind", "wind", "solar", "solar", "wind"],
+    "zone_name": [
+        "Far West",
+        "North",
+        "West",
+        "South",
+        "North Central",
+        "South Central",
+        "Coast",
+        "East",
+    ],
+}
 
-def test_plot_bar_generation_stack_throws_error_for_scenario_ids_not_a_list():
-    with pytest.raises(TypeError):
+mock_solar = pd.DataFrame(
+    {
+        "A": [95, 95, 96, 94],
+        "C": [140, 135, 136, 144],
+        "F": [299, 298, 299, 298],
+        "G": [195, 195, 193, 199],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+mock_wind = pd.DataFrame(
+    {
+        "B": [70, 71, 70, 72],
+        "D": [29, 29, 29, 29],
+        "E": [40, 39, 38, 41],
+        "H": [71, 74, 68, 69],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+mock_pg = pd.DataFrame(
+    {
+        "A": [80, 75, 72, 81],
+        "B": [22, 22, 25, 20],
+        "C": [130, 130, 130, 130],
+        "D": [25, 26, 27, 28],
+        "E": [10, 11, 9, 12],
+        "F": [290, 295, 295, 294],
+        "G": [190, 190, 191, 190],
+        "H": [61, 63, 65, 67],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+mock_demand = pd.DataFrame(
+    {
+        301: [11, 12, 13, 14],
+        302: [2, 3, 8, 10],
+        303: [38, 39, 40, 40],
+        304: [20, 19, 18, 17],
+        305: [4, 3, 2, 1],
+        306: [200, 250, 225, 275],
+        307: [100, 125, 150, 175],
+        308: [36, 36, 37, 38],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+grid_attrs = {"plant": mock_plant}
+scenario = MockScenario(
+    grid_attrs, pg=mock_pg, solar=mock_solar, wind=mock_wind, demand=mock_demand
+)
+scenario.info["name"] = "Best Scenario"
+scenario.info["interconnect"] = "Texas"
+scenario.info["start_date"] = pd.Timestamp(2016, 1, 1)
+scenario.info["end_date"] = pd.Timestamp(2016, 1, 1, 3)
+scenario.state.grid.interconnect = ["Texas"]
+scenario.state.grid.id2zone = {
+    k: v for k, v in zip(mock_plant["zone_id"], mock_plant["zone_name"])
+}
+scenario.state.grid.zone2id = {v: k for k, v in scenario.state.grid.id2zone.items()}
+
+
+@patch("postreise.plot.plot_bar_generation_stack.Scenario", return_value=scenario)
+def test_plot_bar_generation_stack(monkeypatch):
+    plot_bar_generation_stack(
+        "Texas", 1000, "wind", area_types="interconnect", plot_show=False
+    )
+    plot_bar_generation_stack(
+        "Texas",
+        1000,
+        "wind",
+        area_types="interconnect",
+        scenario_names="Worst Scenario",
+        plot_show=False,
+    )
+    plot_bar_generation_stack(
+        "Far West",
+        200,
+        "solar",
+        area_types="loadzone",
+        titles={"Far West": "Where?"},
+        t2c={"solar": "#FFBB45"},
+        t2hc={"solar_curtailment": "#996100"},
+        t2l={"solar": "shiny"},
+        curtailment_split=False,
+        plot_show=False,
+    )
+
+
+def test_plot_bar_generation_stack_argument_type():
+    with pytest.raises(TypeError) as excinfo:
         plot_bar_generation_stack(
             "Western",
             {823, 824},
             ["wind", "solar", "coal"],
         )
+    assert "scenario_ids must be a int, str or list" in str(excinfo.value)
 
-
-def test_plot_bar_generation_stack_throws_error_for_resources_not_a_list():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as excinfo:
         plot_bar_generation_stack(
             "Western",
             [823, 824],
             {"wind", "solar", "coal"},
         )
+    assert "resources must be a list or str" in str(excinfo.value)
 
-
-def test_plot_bar_generation_stack_throws_error_for_different_length_of_areas_and_area_types():
-    with pytest.raises(ValueError):
-        plot_bar_generation_stack(
-            ["Western", "Eastern"],
-            [823, 824],
-            ["wind", "solar", "coal"],
-            area_types="interconnect",
-        )
-
-
-def test_plot_bar_generation_stack_throws_error_for_different_length_of_scenario_ids_and_scenario_names():
-    with pytest.raises(ValueError):
-        plot_bar_generation_stack(
-            ["Western", "Eastern"],
-            [823, 824],
-            ["wind", "solar", "coal"],
-            scenario_names="USA Basecase",
-        )
-
-
-def test_plot_bar_generation_stack_throws_error_for_titles_not_a_dict():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as excinfo:
         plot_bar_generation_stack(
             ["Western", "Eastern"],
             [823, 824],
             ["wind", "solar", "coal"],
             titles=["WECC", "EI"],
         )
+    assert "titles must be a dictionary" in str(excinfo.value)
 
-
-def test_plot_bar_generation_stack_throws_error_for_filenames_not_a_dict():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as excinfo:
         plot_bar_generation_stack(
             ["Western", "Eastern"],
             [823, 824],
@@ -60,3 +148,24 @@ def test_plot_bar_generation_stack_throws_error_for_filenames_not_a_dict():
             save=True,
             filenames=["WECC", "EI"],
         )
+    assert "filenames must be a dictionary" in str(excinfo.value)
+
+
+def test_plot_bar_generation_stack_argument_value():
+    with pytest.raises(ValueError) as excinfo:
+        plot_bar_generation_stack(
+            ["Western", "Eastern"],
+            [823, 824],
+            ["wind", "solar", "coal"],
+            area_types="interconnect",
+        )
+    assert "area_types must have same size as areas" in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        plot_bar_generation_stack(
+            ["Western", "Eastern"],
+            [823, 824],
+            ["wind", "solar", "coal"],
+            scenario_names="USA Basecase",
+        )
+    assert "scenario_names must have same size as scenario_ids" in str(excinfo.value)

--- a/postreise/plot/tests/test_plot_bar_generation_vs_capacity.py
+++ b/postreise/plot/tests/test_plot_bar_generation_vs_capacity.py
@@ -1,9 +1,154 @@
+from unittest.mock import patch
+
 import pandas as pd
+import pytest
+from powersimdata.tests.mock_scenario import MockScenario
 
 from postreise.plot.plot_bar_generation_vs_capacity import (
     _get_bar_display_val,
     make_gen_cap_custom_data,
+    plot_bar_generation_vs_capacity,
 )
+
+mock_plant = {
+    "plant_id": ["A", "B", "C", "D", "E", "F", "G", "H"],
+    "zone_id": [301, 302, 303, 304, 305, 306, 307, 308],
+    "Pmax": [100, 75, 150, 30, 50, 300, 200, 80],
+    "Pmin": [0, 0, 0, 0, 0, 100, 10, 0],
+    "type": ["solar", "wind", "solar", "wind", "wind", "solar", "solar", "wind"],
+    "zone_name": [
+        "Far West",
+        "North",
+        "West",
+        "South",
+        "North Central",
+        "South Central",
+        "Coast",
+        "East",
+    ],
+}
+
+mock_solar = pd.DataFrame(
+    {
+        "A": [95, 95, 96, 94],
+        "C": [140, 135, 136, 144],
+        "F": [299, 298, 299, 298],
+        "G": [195, 195, 193, 199],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+mock_wind = pd.DataFrame(
+    {
+        "B": [70, 71, 70, 72],
+        "D": [29, 29, 29, 29],
+        "E": [40, 39, 38, 41],
+        "H": [71, 74, 68, 69],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+mock_pg = pd.DataFrame(
+    {
+        "A": [80, 75, 72, 81],
+        "B": [22, 22, 25, 20],
+        "C": [130, 130, 130, 130],
+        "D": [25, 26, 27, 28],
+        "E": [10, 11, 9, 12],
+        "F": [290, 295, 295, 294],
+        "G": [190, 190, 191, 190],
+        "H": [61, 63, 65, 67],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+mock_demand = pd.DataFrame(
+    {
+        301: [1100, 1102, 1103, 1104],
+        302: [2344, 2343, 2342, 2341],
+        303: [3875, 3876, 3877, 3878],
+        304: [4924, 4923, 4922, 4921],
+        305: [400, 300, 200, 100],
+        306: [5004, 5003, 5002, 5001],
+        307: [2504, 2503, 2502, 2501],
+        308: [3604, 3603, 3602, 1],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+grid_attrs = {"plant": mock_plant}
+scenario = MockScenario(
+    grid_attrs, pg=mock_pg, solar=mock_solar, wind=mock_wind, demand=mock_demand
+)
+scenario.info["name"] = "Best Scenario"
+scenario.info["interconnect"] = "Texas"
+scenario.info["start_date"] = pd.Timestamp(2016, 1, 1)
+scenario.info["end_date"] = pd.Timestamp(2016, 1, 1, 3)
+scenario.state.grid.interconnect = ["Texas"]
+scenario.state.grid.id2zone = {
+    k: v for k, v in zip(mock_plant["zone_id"], mock_plant["zone_name"])
+}
+scenario.state.grid.zone2id = {v: k for k, v in scenario.state.grid.id2zone.items()}
+
+
+@patch("postreise.plot.plot_bar_generation_vs_capacity.Scenario", return_value=scenario)
+def test_plot_bar_generation_stack(monkeypatch):
+    plot_bar_generation_vs_capacity(
+        areas=["Coast", "Texas"],
+        area_types=["loadzone", "interconnect"],
+        scenario_ids=[22, 44],
+        time_zone="US/Central",
+        plot_show=False,
+    )
+    plot_bar_generation_vs_capacity(
+        areas="Far West",
+        area_types="loadzone",
+        scenario_ids=[22, 44],
+        horizontal=True,
+        plot_show=False,
+    )
+
+
+def test_plot_bar_generation_stack_argument_type():
+    with pytest.raises(TypeError) as excinfo:
+        plot_bar_generation_vs_capacity(
+            areas=["South", "Far West"],
+            area_types=["loadzone", "loadzone"],
+            scenario_ids=[22, 44],
+            resource_labels=["solar", "wind"],
+            plot_show=False,
+        )
+    assert "resource_labels must be a dict" in str(excinfo.value)
+
+
+def test_plot_bar_generation_stack_argument_value():
+    with pytest.raises(ValueError) as excinfo:
+        plot_bar_generation_vs_capacity(
+            areas=["South", "East"],
+            area_types=["loadzone"],
+            scenario_ids=[22, 44],
+            plot_show=False,
+        )
+    assert "area_types must have same size as areas" in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        plot_bar_generation_vs_capacity(
+            areas="South Central",
+            area_types="loadzone",
+            scenario_ids=[1000, 2000],
+            scenario_names=["CaseA", "CaseB", "CaseC"],
+            plot_show=False,
+        )
+    assert "scenario_names must have same size as scenario_ids" in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        plot_bar_generation_vs_capacity(
+            areas="South Central",
+            area_types="loadzone",
+            scenario_ids=1000,
+            plot_show=False,
+        )
+    assert "two scenario and/or custom data must be provided" in str(excinfo.value)
 
 
 def test_get_bar_display_val_greater_than_ten():

--- a/postreise/plot/tests/test_plot_bar_renewable_max_profile_actual.py
+++ b/postreise/plot/tests/test_plot_bar_renewable_max_profile_actual.py
@@ -1,0 +1,117 @@
+import pandas as pd
+import pytest
+from powersimdata.tests.mock_scenario import MockScenario
+
+from postreise.plot.plot_bar_renewable_max_profile_actual import (
+    plot_bar_renewable_max_profile_actual,
+)
+
+mock_plant = {
+    "plant_id": ["A", "B", "C", "D", "E", "F", "G", "H"],
+    "zone_id": [301, 302, 303, 304, 305, 306, 307, 308],
+    "Pmax": [100, 75, 150, 30, 50, 300, 200, 80],
+    "Pmin": [0, 0, 0, 0, 0, 100, 10, 0],
+    "type": ["solar", "wind", "solar", "hydro", "wind", "solar", "ng", "wind"],
+    "zone_name": [
+        "Far West",
+        "North",
+        "West",
+        "South",
+        "North Central",
+        "South Central",
+        "Coast",
+        "East",
+    ],
+}
+
+mock_solar = pd.DataFrame(
+    {
+        "A": [95, 95, 96, 94],
+        "C": [140, 135, 136, 144],
+        "F": [299, 298, 299, 298],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+mock_wind = pd.DataFrame(
+    {
+        "B": [70, 71, 70, 72],
+        "E": [40, 39, 38, 41],
+        "H": [71, 74, 68, 69],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+mock_pg = pd.DataFrame(
+    {
+        "A": [80, 75, 72, 81],
+        "B": [22, 22, 25, 20],
+        "C": [130, 130, 130, 130],
+        "D": [25, 26, 27, 28],
+        "E": [10, 11, 9, 12],
+        "F": [290, 295, 295, 294],
+        "G": [190, 190, 191, 190],
+        "H": [61, 63, 65, 67],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+grid_attrs = {"plant": mock_plant}
+scenario = MockScenario(grid_attrs, pg=mock_pg, solar=mock_solar, wind=mock_wind)
+scenario.info["interconnect"] = "Texas"
+scenario.info["start_date"] = pd.Timestamp(2016, 1, 1)
+scenario.info["end_date"] = pd.Timestamp(2016, 1, 1, 3)
+scenario.state.grid.id2zone = {
+    k: v for k, v in zip(mock_plant["zone_id"], mock_plant["zone_name"])
+}
+scenario.state.grid.zone2id = {v: k for k, v in scenario.state.grid.id2zone.items()}
+
+
+def test_plot_bar_renewable_max_profile_actual():
+    plot_bar_renewable_max_profile_actual(scenario, "Texas", "wind", plot_show=False)
+    plot_bar_renewable_max_profile_actual(
+        scenario,
+        "Texas",
+        "solar",
+        show_as_state=False,
+        percentage=True,
+        plot_show=False,
+    )
+
+
+def test_plot_bar_renewable_max_profile_actual_argument_type():
+    with pytest.raises(TypeError) as excinfo:
+        plot_bar_renewable_max_profile_actual(
+            scenario, ["Texas"], "wind", plot_show=False
+        )
+    assert "interconnect must be a str" in str(excinfo.value)
+
+    with pytest.raises(TypeError) as excinfo:
+        plot_bar_renewable_max_profile_actual(
+            scenario, "Texas", ["coal"], plot_show=False
+        )
+    assert "gen_type must be a str" in str(excinfo.value)
+
+    with pytest.raises(TypeError) as excinfo:
+        plot_bar_renewable_max_profile_actual(
+            scenario, "Texas", "wind", fontsize="15", plot_show=False
+        )
+    assert "fontsize must be either a int or a float" in str(excinfo.value)
+
+
+def test_plot_bar_renewable_max_profile_actual_argument_value():
+    with pytest.raises(ValueError) as excinfo:
+        plot_bar_renewable_max_profile_actual(
+            scenario, "Europe", "wind", plot_show=False
+        )
+    assert (
+        "interconnect must be one of ['Eastern', 'Texas', 'Texas_Western', 'USA', 'Western']"
+        in str(excinfo.value)
+    )
+    with pytest.raises(ValueError) as excinfo:
+        plot_bar_renewable_max_profile_actual(
+            scenario, "Western", "wind", plot_show=False
+        )
+    assert "interconnect is incompatible with scenario's interconnect" in str(
+        excinfo.value
+    )

--- a/postreise/plot/tests/test_plot_bar_shortfall.py
+++ b/postreise/plot/tests/test_plot_bar_shortfall.py
@@ -1,41 +1,135 @@
+from unittest.mock import patch
+
+import numpy as np
 import pandas as pd
 import pytest
+from powersimdata.tests.mock_scenario import MockScenario
 
 from postreise.plot.plot_bar_shortfall import plot_bar_shortfall
 
+mock_plant = {
+    "plant_id": ["A", "B", "C", "D", "E", "F", "G", "H"],
+    "zone_id": [301, 302, 303, 304, 305, 306, 307, 308],
+    "Pmax": [100, 75, 150, 30, 50, 300, 200, 80],
+    "Pmin": [0, 0, 0, 0, 0, 100, 10, 0],
+    "type": ["solar", "wind", "solar", "hydro", "wind", "solar", "ng", "wind"],
+    "zone_name": [
+        "Far West",
+        "North",
+        "West",
+        "South",
+        "North Central",
+        "South Central",
+        "Coast",
+        "East",
+    ],
+}
 
-def test_plot_bar_shortfall_throws_error_for_target_df_not_a_pandas_dataframe():
-    with pytest.raises(TypeError):
+mock_solar = pd.DataFrame(
+    {
+        "A": [95, 95, 96, 94],
+        "C": [140, 135, 136, 144],
+        "F": [299, 298, 299, 298],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+mock_wind = pd.DataFrame(
+    {
+        "B": [70, 71, 70, 72],
+        "E": [40, 39, 38, 41],
+        "H": [71, 74, 68, 69],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+mock_pg = pd.DataFrame(
+    {
+        "A": [80, 75, 72, 81],
+        "B": [22, 22, 25, 20],
+        "C": [130, 130, 130, 130],
+        "D": [25, 26, 27, 28],
+        "E": [10, 11, 9, 12],
+        "F": [290, 295, 295, 294],
+        "G": [190, 190, 191, 190],
+        "H": [61, 63, 65, 67],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+mock_demand = pd.DataFrame(
+    {
+        301: [11, 12, 13, 14],
+        302: [2, 3, 8, 10],
+        303: [38, 39, 40, 40],
+        304: [20, 19, 18, 17],
+        305: [4, 3, 2, 1],
+        306: [200, 250, 225, 275],
+        307: [100, 125, 150, 175],
+        308: [36, 36, 37, 38],
+    },
+    index=pd.date_range(start="2016-01-01", periods=4, freq="H"),
+)
+
+grid_attrs = {"plant": mock_plant}
+scenario = MockScenario(
+    grid_attrs, pg=mock_pg, solar=mock_solar, wind=mock_wind, demand=mock_demand
+)
+scenario.info["name"] = "Best Scenario"
+scenario.info["interconnect"] = "Texas"
+scenario.info["start_date"] = pd.Timestamp(2016, 1, 1)
+scenario.info["end_date"] = pd.Timestamp(2016, 1, 1, 3)
+scenario.state.grid.interconnect = ["Texas"]
+scenario.state.grid.id2zone = {
+    k: v for k, v in zip(mock_plant["zone_id"], mock_plant["zone_name"])
+}
+scenario.state.grid.zone2id = {v: k for k, v in scenario.state.grid.id2zone.items()}
+
+target = pd.DataFrame(
+    {
+        "ce_target_fraction": [0.2437],
+        "allowed_resources": ["solar, wind"],
+        "external_ce_addl_historical_amount": [0.00],
+        "solar_percentage": [np.nan],
+        "area_type": [np.nan],
+    },
+    index=["Texas"],
+)
+target.index.name = "region_name"
+
+
+@patch("postreise.plot.plot_bar_shortfall.Scenario", return_value=scenario)
+def test_plot_bar_shortfall(monkeypatch):
+    plot_bar_shortfall("Texas", 500, target, plot_show=False)
+    plot_bar_shortfall(
+        "Texas",
+        500,
+        target,
+        baseline_scenario=1,
+        baseline_scenario_name="Baseline",
+        plot_show=False,
+    )
+
+
+def test_plot_bar_shortfall_argument_type():
+    with pytest.raises(TypeError) as excinfo:
         plot_bar_shortfall(
             areas="all",
             scenario_ids=[823, 824],
             target_df="not a dataframe",
         )
+    assert "target_df must be a pandas.DataFrame" in str(excinfo.value)
 
-
-def test_plot_bar_shortfall_throws_error_for_strategy_not_a_dictionary():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as excinfo:
         plot_bar_shortfall(
             areas="all",
             scenario_ids=[823, 824],
             target_df=pd.DataFrame(),
             strategy="collaborative",
         )
+    assert "strategy must be a dict" in str(excinfo.value)
 
-
-def test_plot_bar_shortfall_throws_error_for_different_length_of_scenario_ids_and_scenario_names():
-    with pytest.raises(ValueError):
-        plot_bar_shortfall(
-            areas="all",
-            scenario_ids=[823, 824],
-            target_df=pd.DataFrame(),
-            strategy={823: "collaborative"},
-            scenario_names=["USA 2016"],
-        )
-
-
-def test_plot_bar_shortfall_throws_error_for_baseline_scenario_not_a_string_or_integer():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as excinfo:
         plot_bar_shortfall(
             areas="all",
             scenario_ids=[823, 824],
@@ -44,10 +138,9 @@ def test_plot_bar_shortfall_throws_error_for_baseline_scenario_not_a_string_or_i
             scenario_names=["USA 2016", "USA 2020"],
             baseline_scenario=["1", "2", "3"],
         )
+    assert "baseline_scenario must be a str or int" in str(excinfo.value)
 
-
-def test_plot_bar_shortfall_throws_error_for_baseline_scenario_name_not_a_string():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as excinfo:
         plot_bar_shortfall(
             areas="all",
             scenario_ids=[823, 824],
@@ -57,3 +150,16 @@ def test_plot_bar_shortfall_throws_error_for_baseline_scenario_name_not_a_string
             baseline_scenario=823,
             baseline_scenario_name=888,
         )
+    assert "baseline_scenario_name must be a str" in str(excinfo.value)
+
+
+def test_plot_bar_shortfall_argument_value():
+    with pytest.raises(ValueError) as excinfo:
+        plot_bar_shortfall(
+            areas="all",
+            scenario_ids=[823, 824],
+            target_df=pd.DataFrame(),
+            strategy={823: "collaborative"},
+            scenario_names=["USA 2016"],
+        )
+    assert "scenario_names must have same size as scenario_ids" in str(excinfo.value)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Improve test coverage. 

### What the code is doing
* Create new test modules
* Add tests to existing test modules
* Fix bugs
* Update error raised
* Update docstrings
* Use exported methods of `Scenario` object, e.g., s.state.get_demand() -> s.get_demand()
* add possibility to return `matplotlib` axes in plot

### Testing
Run `tox` successfully.

### Where to look
Most noticeable changes:
* additional tests in `test_curtailment`, `test_emissions`, `plot_bar_shortfall` and `test_summarize` modules
* new `test_utilization`, `test_canvas`, `test_plot_bar_generation_max_min_actual` and `plot_bar_renewable_max_profile_actual` modules
* add additional checks in `congestion`,  `plot_bar_generation_max_min_actual` and `plot_bar_renewable_max_profile_actual` modules
* fix bug in `plot_bar_generation_stack`

### Usage Example/Visuals
Before:
```
Name                                                              Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------------------------------------------
postreise/__init__.py                                                 0      0      0      0   100%
postreise/analyze/__init__.py                                         0      0      0      0   100%
postreise/analyze/demand.py                                          13      0      2      0   100%
postreise/analyze/generation/__init__.py                              0      0      0      0   100%
postreise/analyze/generation/binding.py                              27      0      0      0   100%
postreise/analyze/generation/capacity.py                             48      0      4      0   100%
postreise/analyze/generation/costs.py                                24      1     10      1    94%
postreise/analyze/generation/curtailment.py                          74     21     20      0    73%
postreise/analyze/generation/emissions.py                            52      4     24      4    89%
postreise/analyze/generation/summarize.py                            71      3     14      3    93%
postreise/analyze/generation/tests/__init__.py                        1      0      0      0   100%
postreise/analyze/generation/tests/test_binding.py                  119      0     10      0   100%
postreise/analyze/generation/tests/test_capacity.py                  85      0      4      0   100%
postreise/analyze/generation/tests/test_costs.py                     35      0      2      0   100%
postreise/analyze/generation/tests/test_curtailment.py               98      0     24      0   100%
postreise/analyze/generation/tests/test_emissions.py                 87      0     18      0   100%
postreise/analyze/generation/tests/test_summarize.py                 70      0      8      0   100%
postreise/analyze/tests/__init__.py                                   0      0      0      0   100%
postreise/analyze/tests/test_demand.py                               18      0      0      0   100%
postreise/analyze/tests/test_time.py                                366      0    112      0   100%
postreise/analyze/time.py                                            71      0     50      2    98%
postreise/analyze/transmission/__init__.py                            0      0      0      0   100%
postreise/analyze/transmission/congestion.py                         20      2      4      2    83%
postreise/analyze/transmission/tests/__init__.py                      1      0      0      0   100%
postreise/analyze/transmission/tests/test_congestion_surplus.py      36      0      4      0   100%
postreise/analyze/transmission/utilization.py                        48     48      8      0     0%
postreise/data/__init__.py                                            0      0      0      0   100%
postreise/plot/__init__.py                                            0      0      0      0   100%
postreise/plot/canvas.py                                             26     26     24      0     0%
postreise/plot/check.py                                              19      0     12      0   100%
postreise/plot/colors.py                                              8      0      0      0   100%
postreise/plot/plot_bar_generation_max_min_actual.py                 39     39     14      0     0%
postreise/plot/plot_bar_generation_stack.py                         106     76     72      3    29%
postreise/plot/plot_bar_generation_vs_capacity.py                   129     98     72      1    22%
postreise/plot/plot_bar_renewable_max_profile_actual.py              47     47     18      0     0%
postreise/plot/plot_bar_shortfall.py                                 85     65     46      5    25%
postreise/plot/plot_capacity_map.py                                  63     63     16      0     0%
postreise/plot/plot_carbon_bar.py                                    38     38     17      0     0%
postreise/plot/plot_carbon_map.py                                   111    111     24      0     0%
postreise/plot/plot_curtailment_ts.py                                79     79     26      0     0%
postreise/plot/plot_energy_carbon_stack.py                           81     81     49      0     0%
postreise/plot/plot_generation_ts_stack.py                          124    124     52      0     0%
postreise/plot/plot_heatmap.py                                       43     43     14      0     0%
postreise/plot/plot_interconnection_map.py                           67     67     22      0     0%
postreise/plot/plot_lmp_map.py                                       53     53     16      0     0%
postreise/plot/plot_pie_generation_vs_capacity.py                    95     65     62     10    31%
postreise/plot/plot_powerflow_snapshot.py                            93     93     30      0     0%
postreise/plot/plot_scatter_capacity_vs_capacity_factor.py           42     42     20      0     0%
postreise/plot/plot_scatter_capacity_vs_cost_curve_slope.py          34     34     14      0     0%
postreise/plot/plot_scatter_capacity_vs_curtailment.py               47     47     20      0     0%
postreise/plot/plot_shadowprice_map.py                              107     52     22      0    52%
postreise/plot/plot_sim_vs_hist.py                                   46     46     16      0     0%
postreise/plot/plot_states.py                                       119    119     52      0     0%
postreise/plot/plot_tornado.py                                       22     22      4      0     0%
postreise/plot/plot_transmission_upgrades_map.py                     78     78     18      0     0%
postreise/plot/plot_utilization_map.py                               77     77     18      0     0%
postreise/plot/projection_helpers.py                                 40     33     15      0    13%
postreise/plot/tests/__init__.py                                      0      0      0      0   100%
postreise/plot/tests/test_check.py                                   22      2     10      4    81%
postreise/plot/tests/test_plot_bar_generation_stack.py               20      0      0      0   100%
postreise/plot/tests/test_plot_bar_generation_vs_capacity.py         29      0      0      0   100%
postreise/plot/tests/test_plot_bar_shortfall.py                      18      0      0      0   100%
postreise/plot/tests/test_plot_pie_generation_vs_capacity.py         17      0      0      0   100%
postreise/plot/tests/test_plot_shadowprice_map.py                    64      0      8      0   100%
---------------------------------------------------------------------------------------------------
TOTAL                                                              3452   1799   1121     35    45%

```

After:
```
Name                                                                 Stmts   Miss Branch BrPart  Cover
------------------------------------------------------------------------------------------------------
postreise/__init__.py                                                    0      0      0      0   100%
postreise/analyze/__init__.py                                            0      0      0      0   100%
postreise/analyze/demand.py                                             13      0      2      0   100%
postreise/analyze/generation/__init__.py                                 0      0      0      0   100%
postreise/analyze/generation/binding.py                                 27      0      0      0   100%
postreise/analyze/generation/capacity.py                                48      0      4      0   100%
postreise/analyze/generation/costs.py                                   24      0     10      0   100%
postreise/analyze/generation/curtailment.py                             74      0     20      0   100%
postreise/analyze/generation/emissions.py                               50      1     22      1    97%
postreise/analyze/generation/summarize.py                               71      1     14      1    98%
postreise/analyze/generation/tests/__init__.py                           1      0      0      0   100%
postreise/analyze/generation/tests/test_binding.py                     119      0     10      0   100%
postreise/analyze/generation/tests/test_capacity.py                     85      0      4      0   100%
postreise/analyze/generation/tests/test_costs.py                        40      0      2      0   100%
postreise/analyze/generation/tests/test_curtailment.py                 147      0     44      0   100%
postreise/analyze/generation/tests/test_emissions.py                   104      0     20      0   100%
postreise/analyze/generation/tests/test_summarize.py                    82      0     12      0   100%
postreise/analyze/tests/__init__.py                                      0      0      0      0   100%
postreise/analyze/tests/test_demand.py                                  18      0      0      0   100%
postreise/analyze/tests/test_time.py                                   366      0    112      0   100%
postreise/analyze/time.py                                               71      0     50      1    99%
postreise/analyze/transmission/__init__.py                               0      0      0      0   100%
postreise/analyze/transmission/congestion.py                            16      0      0      0   100%
postreise/analyze/transmission/tests/__init__.py                         1      0      0      0   100%
postreise/analyze/transmission/tests/test_congestion_surplus.py         36      0      4      0   100%
postreise/analyze/transmission/tests/test_utilization.py                26      0      0      0   100%
postreise/analyze/transmission/utilization.py                           48      2      8      2    93%
postreise/data/__init__.py                                               0      0      0      0   100%
postreise/plot/__init__.py                                               0      0      0      0   100%
postreise/plot/canvas.py                                                26      0     24      0   100%
postreise/plot/check.py                                                 19      0     12      0   100%
postreise/plot/colors.py                                                 8      0      0      0   100%
postreise/plot/plot_bar_generation_max_min_actual.py                    53      1     24      1    97%
postreise/plot/plot_bar_generation_stack.py                            106     11     72      6    88%
postreise/plot/plot_bar_generation_vs_capacity.py                      132      7     74     10    92%
postreise/plot/plot_bar_renewable_max_profile_actual.py                 60      1     26      1    98%
postreise/plot/plot_bar_shortfall.py                                    89     16     48      9    80%
postreise/plot/plot_capacity_map.py                                     63     63     16      0     0%
postreise/plot/plot_carbon_bar.py                                       38     38     17      0     0%
postreise/plot/plot_carbon_map.py                                      111    111     24      0     0%
postreise/plot/plot_curtailment_ts.py                                   79     79     26      0     0%
postreise/plot/plot_energy_carbon_stack.py                              81     81     49      0     0%
postreise/plot/plot_generation_ts_stack.py                             124    124     52      0     0%
postreise/plot/plot_heatmap.py                                          43     43     14      0     0%
postreise/plot/plot_interconnection_map.py                              67     67     22      0     0%
postreise/plot/plot_lmp_map.py                                          53     53     16      0     0%
postreise/plot/plot_pie_generation_vs_capacity.py                       95     65     62     10    31%
postreise/plot/plot_powerflow_snapshot.py                               93     93     30      0     0%
postreise/plot/plot_scatter_capacity_vs_capacity_factor.py              42     42     20      0     0%
postreise/plot/plot_scatter_capacity_vs_cost_curve_slope.py             34     34     14      0     0%
postreise/plot/plot_scatter_capacity_vs_curtailment.py                  47     47     20      0     0%
postreise/plot/plot_shadowprice_map.py                                 107     52     22      0    52%
postreise/plot/plot_sim_vs_hist.py                                      46     46     16      0     0%
postreise/plot/plot_states.py                                          119    119     52      0     0%
postreise/plot/plot_tornado.py                                          22     22      4      0     0%
postreise/plot/plot_transmission_upgrades_map.py                        78     78     18      0     0%
postreise/plot/plot_utilization_map.py                                  77     77     18      0     0%
postreise/plot/projection_helpers.py                                    40     33     15      0    13%
postreise/plot/tests/__init__.py                                         0      0      0      0   100%
postreise/plot/tests/test_canvas.py                                     28      0      0      0   100%
postreise/plot/tests/test_check.py                                      22      2     10      4    81%
postreise/plot/tests/test_plot_bar_generation_max_min_actual.py         33      0      4      0   100%
postreise/plot/tests/test_plot_bar_generation_stack.py                  44      0      4      0   100%
postreise/plot/tests/test_plot_bar_generation_vs_capacity.py            64      0      4      0   100%
postreise/plot/tests/test_plot_bar_renewable_max_profile_actual.py      35      0      4      0   100%
postreise/plot/tests/test_plot_bar_shortfall.py                         43      0      4      0   100%
postreise/plot/tests/test_plot_pie_generation_vs_capacity.py            17      0      0      0   100%
postreise/plot/tests/test_plot_shadowprice_map.py                       64      0      8      0   100%
------------------------------------------------------------------------------------------------------
TOTAL                                                                 3769   1409   1183     46    61%
```
### Time estimate
30min
