### PR TITLE
ci: trigger stable image build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,11 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Build and publish docker image
+        uses: Breakthrough-Energy/actions/workflow-trigger@main
+        with:
+          repo: plug
+          workflow_id: 12413223
+          token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
+          inputs: '{"imageTags": "stable"}'


### PR DESCRIPTION
### Purpose
Automatically build and push the `postreise:stable` image when we release a new package to PyPI. 

### What the code is doing
Add the step to the workflow to trigger the docker build workflow in plug. 

### Testing
Tested the workflow in my test-ci repo. What I'm not totally sure of is if there is a delay, cache, etc somewhere that could cause the docker build to still pick up the old package. We'll see when we run this, and worst case will have to run the workflow again manually.

### Where to look
For reference, the workflow id comes from the api: https://api.github.com/repos/Breakthrough-Energy/plug/actions/workflows

### Time estimate
5 min
