### PR TITLE
Fix typo in argument to workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,4 @@ jobs:
           repo: plug
           workflow_id: 12413223
           token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
-          inputs: '{"imageTags": "stable"}'
+          inputs: '{"imageTag": "stable"}'


### PR DESCRIPTION
### Purpose
We should trigger a docker build of the `postreise:stable` image when we publish a new release to PyPI. However, this will not work if the input argument is not spelled correctly. The workflow doesn't explicitly fail, but it does emit the following [error message](https://github.com/Breakthrough-Energy/PostREISE/runs/7906863422?check_suite_focus=true#step:9:29). 

### What the code is doing
Change the argument name to match the workflow being run - see https://github.com/Breakthrough-Energy/plug/blob/main/.github/workflows/docker-build.yml#L6

### Testing
I believe this was tested when I added the parameterization here https://github.com/Breakthrough-Energy/actions/pull/8, but that didn't stop typos from occurring. Not sure how to test unless we do another release, but we can run the docker build workflow manually, so it's not an issue.

### Time estimate
1 min
