### PR TITLE
Update plotting documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,30 +1,36 @@
-This guide will demonstrate how to regenerate the plots used in the documentation here.
-The requirements are
-1) Have docker installed
-2) Download the [PlotData] zip file containing the scenarios used
+### Requirements
+This guide will demonstrate how to regenerate the plots used in the
+[documentation][docs]. The only requirement is that docker is installed. The
+scenarios used will be downloaded from blob storage, which may take a while but
+should happen automatically.
 
-Next, extract the data to your home directory, or change the expected location in the
-docker-compose.yml file.
-
-
-Start the container, which will provide a notebook environment for running the code
-snippets.
+### Usage
+First, go to this directory, then start the container, which will provide a
+notebook environment for running the code snippets.
 ```
+cd docs
 docker compose up
 ```
 
-After copying the notebook url from the output, start the `run_snippets.ipynb` notebook
-and run through it. For the most part, no interaction is required. The exception is any
-bokeh plots which must be manually saved as png (currently only the powerflow snapshot). 
+Access the notebook in your browser using the localhost url given by jupyter.
+NOTE: if the host port is already in use by another container, it can be
+changed to one that is available (e.g. 10001). In this case, you'll need to
+change the port in the url to match, since the one given by jupyter is the port
+inside the container.
 
-One may notice that the first part of the notebook contains code to generate the cells
-used subsequently. This is due to (as far as I know) lack of support in jupyterlab for
-programmatically adding new cells, so as a result, any changes to the configuration may
-require a developer to rerun this part and copy/paste the output as needed. In most
-cases, one can simply run it with no changes, since the notebook is pre-populated.
+Now simply run the notebook to regenerate the plots. For the most part, no
+interaction is required. The exception is any bokeh plots which must be
+manually saved as png (currently only the powerflow snapshot). 
 
-The output from each snippet will be saved in the `img2/` directory, similar to `img/` which 
-is checked into git. From here, it's up to the user to compare results and commit the new plots if they look
-good.
+One may notice that the first part of the notebook contains code to generate
+the cells used subsequently. This is due to (as far as I know) lack of support
+in jupyterlab for programmatically adding new cells, so as a result, any
+changes to the configuration may require a developer to rerun this part and
+copy/paste the output as needed. In most cases, one can simply run it with no
+changes, since the notebook is pre-populated.
 
-[PlotData]: https://besciences.blob.core.windows.net/snapshots/PlotData.zip
+The output from each snippet will be saved in the `img2/` directory, similar to
+`img/` which is checked into git. From here, it's up to the user to compare
+results and commit the new plots if they look good.
+
+[docs]: https://breakthrough-energy.github.io/docs/postreise/index.html

--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -1,17 +1,15 @@
-version: '3.7'
-
 services:
   postreise:
-    container_name: postreise
-    hostname: postreise
+    container_name: postreise_docs
+    hostname: postreise_docs
     image: ghcr.io/breakthrough-energy/postreise:latest
     stdin_open: true # docker run -i
     tty: true        # docker run -t
     working_dir: /app
     volumes:
-      - ~/PlotData:/mnt/bes/pcm
+      - ~/ScenarioData:/mnt/bes/pcm
       - ./:/app
     ports:
-      - "10000:10000"
+      - 10000:10000
     environment:
       - DEPLOYMENT_MODE=1

--- a/docs/helper.py
+++ b/docs/helper.py
@@ -1,3 +1,5 @@
+import base64
+
 mpl_config = {
     "single": {
         "curtailment_eastern": (
@@ -41,4 +43,5 @@ bokeh_config = {
 def save_matplotlib(result, filename):
     for i, output in enumerate(result.outputs):
         with open(filename[i], "wb") as f:
-            f.write(output.data["image/png"])
+            content = output.data["image/png"].encode()
+            f.write(base64.decodebytes(content))


### PR DESCRIPTION
### Purpose
After the latest release of powersimdata and postreise, any scenario can be loaded from blob storage, so there is no need to download a separate zip file in order to create the plots used in the tutorial. As such we can simplify the readme for this process.

### What the code is doing
Update the readme, fix an issue saving the base64 encoded image data (not sure if this is due to a jupyter/ipython update to how outputs are handled, but didn't care enough to find out), and rerun the notebook to ensure it works. I also removed the pf snapshot from the output, which reduces the notebook size from 17MB to 20KB. 

### Testing
Regenerated the plots and did some spot checks between `docs/img` (currently in git) and `docs/img2` (where new outputs are written). So far I've only seen minor differences in the formatting, e.g. different sized image, but same plot. I'll continue looking into these but it should be fine.


### Usage Example/Visuals
Feel free to run the notebook.

### Time estimate
10 min
