### PR TITLE
docs: switch order of plots to match notebook

### DIFF
--- a/docs/code/curtailment_eastern.py
+++ b/docs/code/curtailment_eastern.py
@@ -10,7 +10,7 @@ t2c = {"wind_curtailment": "blue", "solar_curtailment": "blue"}
 plot_curtailment_time_series(
     scenario,
     "Eastern",
-    ["wind", "solar"],
+    ["solar", "wind"],
     time_freq="D",
     t2c=t2c,
     label_fontsize=30,


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Switch the order of plots to match the configuration [here](https://github.com/Breakthrough-Energy/PostREISE/blob/develop/docs/helper.py#L6) which is used to generate the notebook cell, then subsequently save the plots. I noticed while comparing the recently generated plots that the `curtailment_solar_eastern_ts.png` was actually for wind, and vice versa. This was slightly simpler than fixing helper.py and the notebook.

### What the code is doing
See above.

### Testing
Ran the notebook and compared plots. Checked the `plot.rst` to make sure there is no dependence on the order (it just includes the two images)

### Time estimate
30 sec
