### PR TITLE
Fix warnings raised by tests

### DIFF
--- a/postreise/plot/plot_scatter_capacity_vs_curtailment.py
+++ b/postreise/plot/plot_scatter_capacity_vs_curtailment.py
@@ -84,7 +84,7 @@ def plot_scatter_capacity_vs_curtailment(
     plant_list = get_plant_id_for_resources_in_area(
         scenario, area, resources, area_type=area_type
     )
-    curtailment = curtailment[set(plant_list) & set(curtailment.columns)]
+    curtailment = curtailment[list(set(plant_list) & set(curtailment.columns))]
     curtailment = change_time_zone(curtailment, time_zone)
     if not time_range:
         time_range = (

--- a/postreise/plot/tests/conftest.py
+++ b/postreise/plot/tests/conftest.py
@@ -1,0 +1,8 @@
+import matplotlib.pyplot as plt
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def plt_close():
+    yield
+    plt.close("all")

--- a/postreise/plot/tests/test_plot_capacity_map.py
+++ b/postreise/plot/tests/test_plot_capacity_map.py
@@ -19,14 +19,14 @@ mock_plant = {
         94.7977,
     ],
     "Pmax": [1000, 750, 1500, 300, 500, 300, 200, 800],
-    "type": ["coal", "ng", "coal", "coal", "wind", "ng", "coal", "solar"],
+    "type": ["coal", "coal", "coal", "coal", "wind", "coal", "coal", "solar"],
 }
 
 scenario = MockScenario({"plant": mock_plant})
 
 
 def test_map_plant_capacity():
-    canvas = map_plant_capacity(scenario, ["ng"])
+    canvas = map_plant_capacity(scenario, ["coal"])
     assert isinstance(canvas, plt.Figure)
 
     ct = {
@@ -49,7 +49,7 @@ def test_map_plant_capacity():
     scenario.state.ct = {}
     _ = map_plant_capacity(scenario, ["coal"], disaggregation="new_vs_existing_plants")
 
-    _ = map_plant_capacity(scenario, ["hydro", "ng"])
+    _ = map_plant_capacity(scenario, ["hydro", "coal"])
 
 
 def test_map_plant_capacity_argument_value():

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --cov=postreise

--- a/tox.ini
+++ b/tox.ini
@@ -24,3 +24,6 @@ ignore = E501,W503,E203,E741
 
 [isort]
 profile = black
+
+[pytest]
+addopts = --cov=postreise


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fix warnings. There are three kinds of warnings
* one raised by `pandas` regarding the type of array used for indexing a data frame
* one raised by `bokeh` because we attempt to edit an empty legend
* one raised by `matplotlib` because too many figures have been opened

Closes #374.

### What the code is doing
* Use a `list` in place of a `set` to  index data frame in `plot_scatter_capacity_vs_curtailment`
* Use only coal generator to ensure glyphs are rendered on the map and legend is created in `test_plot_capacity_map`
* Close all plots in each test module where plots are generated

### Testing
Warnings are not raised

### Where to look
Changes are mostly done in the test modules

### Usage Example/Visuals
N/A

### Time estimate
5min
